### PR TITLE
feature: fixed type mismatch between front and backend

### DIFF
--- a/app/chats/services.py
+++ b/app/chats/services.py
@@ -389,7 +389,7 @@ class ChatService:
 
     @staticmethod
     def send_message(
-        user_id: str, room_id: int, content: str, product_id: Optional[str] = None
+        user_id: str, room_id: int, content: str, message_type: str, product_id: Optional[str] = None
     ) -> Dict[str, Any]:
         """Send a message in a chat room (simplified for socket usage)"""
         try:
@@ -415,7 +415,7 @@ class ChatService:
                     room_id=room_id,
                     sender_id=user_id,
                     content=content,
-                    message_type="text",
+                    message_type=message_type,
                     message_data={"product_id": product_id} if product_id else None,
                 )
 
@@ -450,6 +450,8 @@ class ChatService:
         except Exception as e:
             logger.error(f"Failed to send message: {str(e)}")
             raise APIError("Failed to send message")
+
+
 
     @staticmethod
     def send_offer(

--- a/app/chats/sockets.py
+++ b/app/chats/sockets.py
@@ -171,11 +171,14 @@ class ChatNamespace(Namespace):
 
             room_id = data.get("room_id")
             message_content = data.get("message")
+            message_type =  data.get("message_type")
             product_id = data.get("product_id")
 
             # Validate room access
             if not ChatService.user_has_access_to_room(current_user.id, room_id):
                 return emit("error", {"message": "Access denied to this room"})
+            
+            #TODO: message type needs to be check to make sure it falls within the acceptable types
 
             # Process message through service (includes persistence and validation)
             try:
@@ -184,6 +187,7 @@ class ChatNamespace(Namespace):
                     room_id=room_id,
                     content=message_content,
                     product_id=product_id,
+                    message_type=message_type
                 )
 
                 # Emit to all users in the room (server-side emission)


### PR DESCRIPTION
## Description
Data structure types are now consistent between backend and frontend for chats, across different types including text, video, products and images.

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
Chat still stores these data types as json that are parsed and understood by the frontend. In later versions, we would want to have the server side process these different types and store them separately