### PR TITLE
Fix/chat room creation and message reactions

### DIFF
--- a/app/chats/routes.py
+++ b/app/chats/routes.py
@@ -20,6 +20,7 @@ from .schemas import (
     CreateChatRoomSchema,
     SendMessageSchema,
     ChatMessageReactionCreateSchema,
+    ChatMessageReactionSchema,
     ChatMessageReactionSummarySchema,
 )
 from .services import ChatService, ChatReactionService, DiscountService
@@ -54,12 +55,18 @@ class ChatRooms(MethodView):
                 buyer_id = current_user.id
                 seller_id = room_data.get("seller_id")
                 if not seller_id:
-                    abort(400, message="seller_id is required when creating a chat room as a buyer")
+                    abort(
+                        400,
+                        message="seller_id is required when creating a chat room as a buyer",
+                    )
             else:
                 buyer_id = room_data.get("buyer_id")
                 seller_id = current_user.id
                 if not buyer_id:
-                    abort(400, message="buyer_id is required when creating a chat room as a seller")
+                    abort(
+                        400,
+                        message="buyer_id is required when creating a chat room as a seller",
+                    )
 
             room = ChatService.create_or_get_chat_room(
                 buyer_id=buyer_id,
@@ -190,7 +197,7 @@ class ChatMessageReactions(MethodView):
 
     @login_required
     @bp.arguments(ChatMessageReactionCreateSchema)
-    @bp.response(201)
+    @bp.response(201, ChatMessageReactionSchema)
     def post(self, reaction_data, message_id):
         """Add a reaction to a chat message"""
         try:

--- a/app/chats/schemas.py
+++ b/app/chats/schemas.py
@@ -165,13 +165,17 @@ class ChatMessageReactionSchema(Schema):
     id = fields.Int(dump_only=True)
     message_id = fields.Int(dump_only=True)
     user_id = fields.Str(dump_only=True)
-    reaction_type = fields.Str(dump_only=True)
-    emoji = fields.Str(dump_only=True)
+    reaction_type = fields.Method("get_reaction_type", dump_only=True)
+    emoji = fields.Method("get_emoji", dump_only=True)
     created_at = fields.DateTime(dump_only=True)
 
+    def get_reaction_type(self, obj):
+        rt = obj.reaction_type
+        return rt.value if hasattr(rt, "value") else rt
+
     def get_emoji(self, obj):
-        """Get emoji for reaction type"""
-        return REACTION_EMOJIS.get(obj.reaction_type.value, "👍")
+        key = self.get_reaction_type(obj)
+        return REACTION_EMOJIS.get(key, "👍")
 
 
 class ChatMessageReactionCreateSchema(Schema):

--- a/app/chats/services.py
+++ b/app/chats/services.py
@@ -156,38 +156,34 @@ class ChatService:
         for a given product/request, regardless of which user initiated the conversation.
         """
         try:
-            # Validate that buyer and seller are different users
             if buyer_id == seller_id:
                 raise ValidationError("Cannot create a chat room with yourself")
 
-            # Validate that both users exist
-            buyer = session.query(User).filter(User.id == buyer_id).first()
-            if not buyer:
-                raise NotFoundError(f"Buyer with ID {buyer_id} not found")
-
-            seller = session.query(User).filter(User.id == seller_id).first()
-            if not seller:
-                raise NotFoundError(f"Seller with ID {seller_id} not found")
-
-            # Validate product_id if provided
-            if product_id:
-                product = (
-                    session.query(Product).filter(Product.id == product_id).first()
-                )
-                if not product:
-                    raise NotFoundError(f"Product with ID {product_id} not found")
-
-            # Validate request_id if provided
-            if request_id:
-                request_obj = (
-                    session.query(BuyerRequest)
-                    .filter(BuyerRequest.id == request_id)
-                    .first()
-                )
-                if not request_obj:
-                    raise NotFoundError(f"Request with ID {request_id} not found")
-
             with session_scope() as session:
+                buyer = session.query(User).filter(User.id == buyer_id).first()
+                if not buyer:
+                    raise NotFoundError(f"Buyer with ID {buyer_id} not found")
+
+                seller = session.query(User).filter(User.id == seller_id).first()
+                if not seller:
+                    raise NotFoundError(f"Seller with ID {seller_id} not found")
+
+                if product_id:
+                    product = (
+                        session.query(Product).filter(Product.id == product_id).first()
+                    )
+                    if not product:
+                        raise NotFoundError(f"Product with ID {product_id} not found")
+
+                if request_id:
+                    request_obj = (
+                        session.query(BuyerRequest)
+                        .filter(BuyerRequest.id == request_id)
+                        .first()
+                    )
+                    if not request_obj:
+                        raise NotFoundError(f"Request with ID {request_id} not found")
+
                 # Check if room already exists in either direction
                 # (buyer_id=A, seller_id=B) OR (buyer_id=B, seller_id=A)
                 existing_room = (
@@ -229,9 +225,11 @@ class ChatService:
 
                 return room
 
+        except APIError:
+            raise
         except Exception as e:
-            logger.error(f"Failed to create chat room: {str(e)}")
-            raise APIError("Failed to create chat room")
+            logger.exception("Failed to create chat room: %s", e)
+            raise APIError("Failed to create chat room", status_code=500)
 
     @staticmethod
     def get_user_chat_rooms(
@@ -960,6 +958,33 @@ class ChatReactionService:
     """Service for managing reactions on chat messages"""
 
     @staticmethod
+    def _emit_message_reaction_event(
+        event: str,
+        message_id: int,
+        user_id: str,
+        reaction_type: str,
+        username: Optional[str] = None,
+    ) -> None:
+        """Emit reaction events from HTTP handlers (outside Socket.IO request context)."""
+        from main.extensions import socketio
+
+        reaction_value = (
+            reaction_type.value if hasattr(reaction_type, "value") else reaction_type
+        )
+        socketio.emit(
+            event,
+            {
+                "message_id": message_id,
+                "user_id": user_id,
+                "username": username or "User",
+                "reaction_type": reaction_value,
+                "timestamp": datetime.utcnow().isoformat(),
+            },
+            room=f"message_{message_id}",
+            namespace="/chat",
+        )
+
+    @staticmethod
     def add_message_reaction(user_id: str, message_id: int, reaction_type: str):
         """Add or update a reaction on a chat message"""
         try:
@@ -1006,22 +1031,22 @@ class ChatReactionService:
                 session.add(reaction)
                 session.commit()
 
-                # Emit real-time websocket event
                 try:
-                    from flask_socketio import emit
-
-                    emit(
+                    user = session.query(User).filter(User.id == user_id).first()
+                    ChatReactionService._emit_message_reaction_event(
                         "message_reaction_added",
-                        {
-                            "message_id": message_id,
-                            "user_id": user_id,
-                            "reaction_type": reaction_type,
-                            "timestamp": datetime.utcnow().isoformat(),
-                        },
-                        room=f"message_{message_id}",
+                        message_id,
+                        user_id,
+                        reaction_type_enum,
+                        username=user.username if user else None,
+                    )
+                    redis_client.hincrby(
+                        f"message:{message_id}:reactions",
+                        reaction_type_enum.value,
+                        1,
                     )
                 except Exception as e:
-                    logger.warning(f"Failed to emit message_reaction_added event: {e}")
+                    logger.warning("Failed to emit message_reaction_added event: %s", e)
 
                 return reaction
 
@@ -1056,23 +1081,21 @@ class ChatReactionService:
                 session.delete(reaction)
                 session.commit()
 
-                # Emit real-time websocket event
                 try:
-                    from flask_socketio import emit
-
-                    emit(
+                    user = session.query(User).filter(User.id == user_id).first()
+                    ChatReactionService._emit_message_reaction_event(
                         "message_reaction_removed",
-                        {
-                            "message_id": message_id,
-                            "user_id": user_id,
-                            "reaction_type": reaction_type,
-                            "timestamp": datetime.utcnow().isoformat(),
-                        },
-                        room=f"message_{message_id}",
+                        message_id,
+                        user_id,
+                        reaction_type,
+                        username=user.username if user else None,
+                    )
+                    redis_client.hincrby(
+                        f"message:{message_id}:reactions", reaction_type, -1
                     )
                 except Exception as e:
                     logger.warning(
-                        f"Failed to emit message_reaction_removed event: {e}"
+                        "Failed to emit message_reaction_removed event: %s", e
                     )
 
                 return True


### PR DESCRIPTION
## Description

Fixes several chat API bugs surfaced in production logs:

### Chat room creation (`POST /api/v1/chats/rooms`)
- **Bug:** `cannot access local variable 'session' where it is not associated with a value` — validation queries ran before `session_scope()` opened a session.
- **Fix:** Move buyer/seller/product/request validation inside `with session_scope() as session`.
- **Improvement:** Re-raise `APIError` subclasses (`ValidationError`, `NotFoundError`) so the route returns correct status codes and messages; log and return **500** only for unexpected failures.

### Message reactions (`POST /api/v1/chats/messages/<id>/reactions`)
- **Bug:** `TypeError: Object of type ChatMessageReaction is not JSON serializable` — route returned a raw ORM model with no response schema.
- **Fix:** Add `@bp.response(201, ChatMessageReactionSchema)` and correct schema `reaction_type` / `emoji` serialization via `fields.Method`.

### Reaction WebSocket emit (warning in logs)
- **Bug:** `Failed to emit message_reaction_added event: 'Request' object has no attribute 'namespace'` — `flask_socketio.emit()` was called from an HTTP handler; it expects a Socket.IO request context.
- **Fix:** Emit via `socketio.emit(..., namespace="/chat")` through a shared `_emit_message_reaction_event` helper (aligned with other cross-context emits). Include `username` in the payload and keep Redis reaction counts in sync on add/remove.

## Tickets
Ticket ID [link]

## Related Issue
Fixes #[Issue number]

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Manual verification recommended:

- [ ] `POST /api/v1/chats/rooms` — creates or returns existing room (no 400 from session error)
- [ ] `POST /api/v1/chats/rooms` with invalid seller/product — returns **404** or **422** with a specific message (not generic "Failed to create chat room")
- [ ] `POST /api/v1/chats/messages/<id>/reactions` with `{ "reaction_type": "HEART" }` — **201** with JSON body (`id`, `message_id`, `reaction_type`, `emoji`, etc.)
- [ ] No `namespace` warning in logs on reaction add/remove
- [ ] Clients joined to `/chat` room `message_<id>` receive `message_reaction_added` / `message_reaction_removed`


## Tested & Approved by?
Self Tested @Adebowale-Morakinyo 

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes

**Files changed**
- `app/chats/services.py` — `create_or_get_chat_room`, `ChatReactionService`
- `app/chats/routes.py` — reaction POST response schema
- `app/chats/schemas.py` — `ChatMessageReactionSchema` dump fields

No API contract changes beyond fixing broken responses; reaction POST now returns the documented reaction object instead of 500.