### PR TITLE
Proposed paystack redirection fix

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,7 +4,7 @@ exclude =
     migrations
 
 # Temporary legacy baseline for existing code.
-# Goal: tighten this list gradually as modules are cleaned up.
+# Goal: tighten this list gradually as modules are cleaned up. @amethystcoder
 extend-ignore =
     E222,
     E265,

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,5 @@
 name: Deploy to Markt Server
+# Triggered after successful CI on develop (workflow_run) or manually (workflow_dispatch).
 
 on:
   workflow_run:

--- a/app/chats/routes.py
+++ b/app/chats/routes.py
@@ -20,6 +20,7 @@ from .schemas import (
     CreateChatRoomSchema,
     SendMessageSchema,
     ChatMessageReactionCreateSchema,
+    ChatMessageReactionSchema,
     ChatMessageReactionSummarySchema,
 )
 from .services import ChatService, ChatReactionService, DiscountService
@@ -54,12 +55,18 @@ class ChatRooms(MethodView):
                 buyer_id = current_user.id
                 seller_id = room_data.get("seller_id")
                 if not seller_id:
-                    abort(400, message="seller_id is required when creating a chat room as a buyer")
+                    abort(
+                        400,
+                        message="seller_id is required when creating a chat room as a buyer",
+                    )
             else:
                 buyer_id = room_data.get("buyer_id")
                 seller_id = current_user.id
                 if not buyer_id:
-                    abort(400, message="buyer_id is required when creating a chat room as a seller")
+                    abort(
+                        400,
+                        message="buyer_id is required when creating a chat room as a seller",
+                    )
 
             room = ChatService.create_or_get_chat_room(
                 buyer_id=buyer_id,
@@ -190,7 +197,7 @@ class ChatMessageReactions(MethodView):
 
     @login_required
     @bp.arguments(ChatMessageReactionCreateSchema)
-    @bp.response(201)
+    @bp.response(201, ChatMessageReactionSchema)
     def post(self, reaction_data, message_id):
         """Add a reaction to a chat message"""
         try:

--- a/app/chats/schemas.py
+++ b/app/chats/schemas.py
@@ -165,13 +165,17 @@ class ChatMessageReactionSchema(Schema):
     id = fields.Int(dump_only=True)
     message_id = fields.Int(dump_only=True)
     user_id = fields.Str(dump_only=True)
-    reaction_type = fields.Str(dump_only=True)
-    emoji = fields.Str(dump_only=True)
+    reaction_type = fields.Method("get_reaction_type", dump_only=True)
+    emoji = fields.Method("get_emoji", dump_only=True)
     created_at = fields.DateTime(dump_only=True)
 
+    def get_reaction_type(self, obj):
+        rt = obj.reaction_type
+        return rt.value if hasattr(rt, "value") else rt
+
     def get_emoji(self, obj):
-        """Get emoji for reaction type"""
-        return REACTION_EMOJIS.get(obj.reaction_type.value, "👍")
+        key = self.get_reaction_type(obj)
+        return REACTION_EMOJIS.get(key, "👍")
 
 
 class ChatMessageReactionCreateSchema(Schema):

--- a/app/chats/services.py
+++ b/app/chats/services.py
@@ -156,38 +156,34 @@ class ChatService:
         for a given product/request, regardless of which user initiated the conversation.
         """
         try:
-            # Validate that buyer and seller are different users
             if buyer_id == seller_id:
                 raise ValidationError("Cannot create a chat room with yourself")
 
-            # Validate that both users exist
-            buyer = session.query(User).filter(User.id == buyer_id).first()
-            if not buyer:
-                raise NotFoundError(f"Buyer with ID {buyer_id} not found")
-
-            seller = session.query(User).filter(User.id == seller_id).first()
-            if not seller:
-                raise NotFoundError(f"Seller with ID {seller_id} not found")
-
-            # Validate product_id if provided
-            if product_id:
-                product = (
-                    session.query(Product).filter(Product.id == product_id).first()
-                )
-                if not product:
-                    raise NotFoundError(f"Product with ID {product_id} not found")
-
-            # Validate request_id if provided
-            if request_id:
-                request_obj = (
-                    session.query(BuyerRequest)
-                    .filter(BuyerRequest.id == request_id)
-                    .first()
-                )
-                if not request_obj:
-                    raise NotFoundError(f"Request with ID {request_id} not found")
-
             with session_scope() as session:
+                buyer = session.query(User).filter(User.id == buyer_id).first()
+                if not buyer:
+                    raise NotFoundError(f"Buyer with ID {buyer_id} not found")
+
+                seller = session.query(User).filter(User.id == seller_id).first()
+                if not seller:
+                    raise NotFoundError(f"Seller with ID {seller_id} not found")
+
+                if product_id:
+                    product = (
+                        session.query(Product).filter(Product.id == product_id).first()
+                    )
+                    if not product:
+                        raise NotFoundError(f"Product with ID {product_id} not found")
+
+                if request_id:
+                    request_obj = (
+                        session.query(BuyerRequest)
+                        .filter(BuyerRequest.id == request_id)
+                        .first()
+                    )
+                    if not request_obj:
+                        raise NotFoundError(f"Request with ID {request_id} not found")
+
                 # Check if room already exists in either direction
                 # (buyer_id=A, seller_id=B) OR (buyer_id=B, seller_id=A)
                 existing_room = (
@@ -229,9 +225,11 @@ class ChatService:
 
                 return room
 
+        except APIError:
+            raise
         except Exception as e:
-            logger.error(f"Failed to create chat room: {str(e)}")
-            raise APIError("Failed to create chat room")
+            logger.exception("Failed to create chat room: %s", e)
+            raise APIError("Failed to create chat room", status_code=500)
 
     @staticmethod
     def get_user_chat_rooms(
@@ -960,6 +958,33 @@ class ChatReactionService:
     """Service for managing reactions on chat messages"""
 
     @staticmethod
+    def _emit_message_reaction_event(
+        event: str,
+        message_id: int,
+        user_id: str,
+        reaction_type: str,
+        username: Optional[str] = None,
+    ) -> None:
+        """Emit reaction events from HTTP handlers (outside Socket.IO request context)."""
+        from main.extensions import socketio
+
+        reaction_value = (
+            reaction_type.value if hasattr(reaction_type, "value") else reaction_type
+        )
+        socketio.emit(
+            event,
+            {
+                "message_id": message_id,
+                "user_id": user_id,
+                "username": username or "User",
+                "reaction_type": reaction_value,
+                "timestamp": datetime.utcnow().isoformat(),
+            },
+            room=f"message_{message_id}",
+            namespace="/chat",
+        )
+
+    @staticmethod
     def add_message_reaction(user_id: str, message_id: int, reaction_type: str):
         """Add or update a reaction on a chat message"""
         try:
@@ -1006,22 +1031,22 @@ class ChatReactionService:
                 session.add(reaction)
                 session.commit()
 
-                # Emit real-time websocket event
                 try:
-                    from flask_socketio import emit
-
-                    emit(
+                    user = session.query(User).filter(User.id == user_id).first()
+                    ChatReactionService._emit_message_reaction_event(
                         "message_reaction_added",
-                        {
-                            "message_id": message_id,
-                            "user_id": user_id,
-                            "reaction_type": reaction_type,
-                            "timestamp": datetime.utcnow().isoformat(),
-                        },
-                        room=f"message_{message_id}",
+                        message_id,
+                        user_id,
+                        reaction_type_enum,
+                        username=user.username if user else None,
+                    )
+                    redis_client.hincrby(
+                        f"message:{message_id}:reactions",
+                        reaction_type_enum.value,
+                        1,
                     )
                 except Exception as e:
-                    logger.warning(f"Failed to emit message_reaction_added event: {e}")
+                    logger.warning("Failed to emit message_reaction_added event: %s", e)
 
                 return reaction
 
@@ -1056,23 +1081,21 @@ class ChatReactionService:
                 session.delete(reaction)
                 session.commit()
 
-                # Emit real-time websocket event
                 try:
-                    from flask_socketio import emit
-
-                    emit(
+                    user = session.query(User).filter(User.id == user_id).first()
+                    ChatReactionService._emit_message_reaction_event(
                         "message_reaction_removed",
-                        {
-                            "message_id": message_id,
-                            "user_id": user_id,
-                            "reaction_type": reaction_type,
-                            "timestamp": datetime.utcnow().isoformat(),
-                        },
-                        room=f"message_{message_id}",
+                        message_id,
+                        user_id,
+                        reaction_type,
+                        username=user.username if user else None,
+                    )
+                    redis_client.hincrby(
+                        f"message:{message_id}:reactions", reaction_type, -1
                     )
                 except Exception as e:
                     logger.warning(
-                        f"Failed to emit message_reaction_removed event: {e}"
+                        "Failed to emit message_reaction_removed event: %s", e
                     )
 
                 return True

--- a/app/deliveries/routes.py
+++ b/app/deliveries/routes.py
@@ -117,7 +117,7 @@ class DeliveryAvailableOrders(MethodView):
         """Get available orders for the delivery partner (paginated)."""
         return DeliveryService.get_available_orders(
             current_user.id,
-            search_radius=args.get("search_radius", 3000),
+            search_radius=args.get("search_radius", 5000),
             page=args.get("page", 1),
             per_page=args.get("per_page", 20),
         )

--- a/app/deliveries/schemas.py
+++ b/app/deliveries/schemas.py
@@ -76,7 +76,7 @@ class DeliveryAvailableOrdersQuerySchema(Schema):
     page = fields.Int(validate=validate.Range(min=1), missing=1)
     per_page = fields.Int(validate=validate.Range(min=1, max=50), missing=20)
     search_radius = fields.Int(
-        validate=validate.Range(min=100, max=50000), missing=3000
+        validate=validate.Range(min=100, max=50000), missing=5000
     )
 
 

--- a/app/deliveries/services.py
+++ b/app/deliveries/services.py
@@ -323,149 +323,157 @@ class DeliveryService:
     # either by using postGIS to calculate the distance properly,
     # or by pre-calculating the distance between the delivery partner and the sellers and caching that in Redis, and then just fetching the available orders based on the cached distances
 
+    @staticmethod
+    def get_available_orders(
+        user_id: str,
+        search_radius: int = 5000,
+        page: int = 1,
+        per_page: int = 20,
+    ) -> dict:
+        """Get available orders for the delivery partner with pagination.
+        per_page is capped at 50.
+        """
+        per_page = min(max(1, per_page), 50)
+        page = max(1, page)
 
-@staticmethod
-def get_available_orders(
-    user_id: str,
-    search_radius: int = 5000,
-    page: int = 1,
-    per_page: int = 20,
-) -> dict:
-    """Get available orders for the delivery partner with pagination.
-    per_page is capped at 50.
-    """
-    per_page = min(max(1, per_page), 50)
-    page = max(1, page)
-
-    try:
-        with session_scope() as session:
-            delivery_user = (
-                session.query(DeliveryUser).filter(DeliveryUser.id == user_id).first()
-            )
-
-            if not delivery_user:
-                raise NotFoundError("Delivery partner not found")
-
-            if delivery_user.status == DeliveryStatus.SUSPENDED:
-                raise ForbiddenError("Your account has been suspended")
-
-            if (
-                not delivery_user.last_location
-                or delivery_user.last_location.latitude is None
-                or delivery_user.last_location.longitude is None
-            ):
-                raise ValidationError(
-                    "Location not set. Please update your location before browsing available orders."
+        try:
+            with session_scope() as session:
+                delivery_user = (
+                    session.query(DeliveryUser)
+                    .filter(DeliveryUser.id == user_id)
+                    .first()
                 )
 
-            delivery_lat = delivery_user.last_location.latitude
-            delivery_lng = delivery_user.last_location.longitude
+                # error handling for delivery user not found, suspended, or missing location
+                if not delivery_user:
+                    raise NotFoundError("Delivery partner not found")
 
-            orders = (
-                session.query(Order)
-                .filter(Order.status == OrderStatus.READY_FOR_DELIVERY)
-                .options(
-                    joinedload(Order.shipping_address),
-                    joinedload(Order.items)
-                    .joinedload(OrderItem.seller)
-                    .joinedload(Seller.user)
-                    .joinedload(User.address),
-                )
-                .all()
-            )
+                if delivery_user.status == DeliveryStatus.SUSPENDED:
+                    raise ForbiddenError("Your account has been suspended")
 
-            available_orders = []
-
-            for order in orders:
-                dropoff = order.shipping_address
-
-                if not dropoff or dropoff.latitude is None or dropoff.longitude is None:
-                    continue
-
-                if not order.items:
-                    continue
-
-                seller_pickups = []
-                pickup_distances = []
-                seen_seller_ids = set()
-
-                for item in order.items:
-                    seller = item.seller
-                    if not seller or seller.id in seen_seller_ids:
-                        continue
-
-                    seen_seller_ids.add(seller.id)
-
-                    seller_address = (
-                        getattr(seller.user, "address", None) if seller.user else None
+                if (
+                    not delivery_user.last_location
+                    or delivery_user.last_location.latitude is None
+                    or delivery_user.last_location.longitude is None
+                ):
+                    raise ValidationError(
+                        "Location not set. Please update your location before browsing available orders."
                     )
 
+                delivery_lat = delivery_user.last_location.latitude
+                delivery_lng = delivery_user.last_location.longitude
+
+                orders = (
+                    session.query(Order)
+                    .filter(Order.status == OrderStatus.READY_FOR_DELIVERY)
+                    .options(
+                        joinedload(Order.shipping_address),
+                        joinedload(Order.items)
+                        .joinedload(OrderItem.seller)
+                        .joinedload(Seller.user)
+                        .joinedload(User.address),
+                    )
+                    .all()
+                )
+
+                available_orders = []
+
+                for order in orders:
+                    dropoff = order.shipping_address
+
                     if (
-                        not seller_address
-                        or seller_address.latitude is None
-                        or seller_address.longitude is None
+                        not dropoff
+                        or dropoff.latitude is None
+                        or dropoff.longitude is None
                     ):
                         continue
 
-                    pickup_lat = seller_address.latitude
-                    pickup_lng = seller_address.longitude
+                    if not order.items:
+                        continue
 
-                    seller_pickups.append({"lat": pickup_lat, "lng": pickup_lng})
+                    seller_pickups = []
+                    pickup_distances = []
+                    seen_seller_ids = set()
 
-                    distance = DeliveryService.haversine_distance(
-                        delivery_lat, delivery_lng, pickup_lat, pickup_lng
+                    for item in order.items:
+                        seller = item.seller
+                        if not seller or seller.id in seen_seller_ids:
+                            continue
+
+                        seen_seller_ids.add(seller.id)
+
+                        seller_address = (
+                            getattr(seller.user, "address", None)
+                            if seller.user
+                            else None
+                        )
+
+                        if (
+                            not seller_address
+                            or seller_address.latitude is None
+                            or seller_address.longitude is None
+                        ):
+                            continue
+
+                        pickup_lat = seller_address.latitude
+                        pickup_lng = seller_address.longitude
+
+                        seller_pickups.append({"lat": pickup_lat, "lng": pickup_lng})
+
+                        distance = DeliveryService.haversine_distance(
+                            delivery_lat, delivery_lng, pickup_lat, pickup_lng
+                        )
+                        pickup_distances.append(distance)
+
+                    if not seller_pickups:
+                        continue
+
+                    # Better than average for multi-pickup feasibility
+                    max_distance = max(pickup_distances)
+
+                    if max_distance > search_radius:
+                        continue
+
+                    estimated_earnings = (
+                        order.shipping_fee if order.shipping_fee is not None else 0
                     )
-                    pickup_distances.append(distance)
 
-                if not seller_pickups:
-                    continue
+                    available_orders.append(
+                        {
+                            "order_id": order.id,
+                            "pickup": seller_pickups,
+                            "dropoff": {
+                                "lat": dropoff.latitude,
+                                "lng": dropoff.longitude,
+                            },
+                            "distance_meters": round(max_distance, 2),
+                            "estimated_earnings": estimated_earnings,
+                        }
+                    )
 
-                # Better than average for multi-pickup feasibility
-                max_distance = max(pickup_distances)
+                total = len(available_orders)
+                start = (page - 1) * per_page
+                end = start + per_page
+                page_orders = available_orders[start:end]
 
-                if max_distance > search_radius:
-                    continue
-
-                estimated_earnings = (
-                    order.shipping_fee if order.shipping_fee is not None else 0
-                )
-
-                available_orders.append(
-                    {
-                        "order_id": order.id,
-                        "pickup": seller_pickups,
-                        "dropoff": {
-                            "lat": dropoff.latitude,
-                            "lng": dropoff.longitude,
-                        },
-                        "distance_meters": round(max_distance, 2),
-                        "estimated_earnings": estimated_earnings,
-                    }
-                )
-
-            total = len(available_orders)
-            start = (page - 1) * per_page
-            end = start + per_page
-            page_orders = available_orders[start:end]
-
-            return {
-                "range_meters": search_radius,
-                "orders": page_orders,
-                "page": page,
-                "per_page": per_page,
-                "total": total,
-                "total_pages": (total + per_page - 1) // per_page if total else 0,
-            }
-    except (NotFoundError, ForbiddenError, ValidationError):
-        raise
-    except SQLAlchemyError as e:
-        logger.exception(f"Database error fetching available orders: {str(e)}")
-        raise APIError(
-            "Database error while fetching available orders", status_code=500
-        )
-    except Exception as e:
-        logger.exception(f"Unexpected error fetching available orders: {str(e)}")
-        raise APIError("Failed to fetch available orders", status_code=500)
+                return {
+                    "range_meters": search_radius,
+                    "orders": page_orders,
+                    "page": page,
+                    "per_page": per_page,
+                    "total": total,
+                    "total_pages": (total + per_page - 1) // per_page if total else 0,
+                }
+        except (NotFoundError, ForbiddenError, ValidationError):
+            raise
+        except SQLAlchemyError as e:
+            logger.exception(f"Database error fetching available orders: {str(e)}")
+            raise APIError(
+                "Database error while fetching available orders", status_code=500
+            )
+        except Exception as e:
+            logger.exception(f"Unexpected error fetching available orders: {str(e)}")
+            raise APIError("Failed to fetch available orders", status_code=500)
 
     @staticmethod
     def haversine_distance(lat1, lng1, lat2, lng2):

--- a/app/deliveries/services.py
+++ b/app/deliveries/services.py
@@ -18,7 +18,7 @@ from sqlalchemy.orm import joinedload
 from external.redis import redis_client
 from app.libs.session import session_scope
 from app.libs.pagination import Paginator
-from app.libs.errors import APIError, NotFoundError, ValidationError
+from app.libs.errors import APIError, NotFoundError, ValidationError, ForbiddenError
 from app.libs.email_service import email_service
 
 # app imports
@@ -327,7 +327,7 @@ class DeliveryService:
 @staticmethod
 def get_available_orders(
     user_id: str,
-    search_radius: int = 3000,
+    search_radius: int = 5000,
     page: int = 1,
     per_page: int = 20,
 ) -> dict:
@@ -346,26 +346,24 @@ def get_available_orders(
             if not delivery_user:
                 raise NotFoundError("Delivery partner not found")
 
+            if delivery_user.status == DeliveryStatus.SUSPENDED:
+                raise ForbiddenError("Your account has been suspended")
+
             if (
                 not delivery_user.last_location
                 or delivery_user.last_location.latitude is None
                 or delivery_user.last_location.longitude is None
             ):
-                return {
-                    "range_meters": search_radius,
-                    "orders": [],
-                    "page": page,
-                    "per_page": per_page,
-                    "total": 0,
-                    "total_pages": 0,
-                }
+                raise ValidationError(
+                    "Location not set. Please update your location before browsing available orders."
+                )
 
             delivery_lat = delivery_user.last_location.latitude
             delivery_lng = delivery_user.last_location.longitude
 
             orders = (
                 session.query(Order)
-                .filter(Order.status == OrderStatus.PROCESSING)
+                .filter(Order.status == OrderStatus.READY_FOR_DELIVERY)
                 .options(
                     joinedload(Order.shipping_address),
                     joinedload(Order.items)
@@ -458,10 +456,13 @@ def get_available_orders(
                 "total": total,
                 "total_pages": (total + per_page - 1) // per_page if total else 0,
             }
-    except NotFoundError:
+    except (NotFoundError, ForbiddenError, ValidationError):
         raise
+    except SQLAlchemyError as e:
+        logger.exception(f"Database error fetching available orders: {str(e)}")
+        raise APIError("Database error while fetching available orders", status_code=500)
     except Exception as e:
-        logger.exception(f"Error fetching available orders {str(e)}")
+        logger.exception(f"Unexpected error fetching available orders: {str(e)}")
         raise APIError("Failed to fetch available orders", status_code=500)
 
     @staticmethod

--- a/app/deliveries/services.py
+++ b/app/deliveries/services.py
@@ -348,12 +348,10 @@ def get_available_orders(user_id: str, search_radius: int = 3000, page: int = 1,
                 .filter(Order.status == OrderStatus.PROCESSING)
                 .options(
                     joinedload(Order.shipping_address),
-                    (
-                        joinedload(Order.items)
-                        .joinedload(OrderItem.seller)
-                        .joinedload(Seller.user)
-                        .joinedload(User.address)
-                    ),
+                    joinedload(Order.items)
+                    .joinedload(OrderItem.seller)
+                    .joinedload(Seller.user)
+                    .joinedload(User.address),
                 )
                 .all()
             )

--- a/app/deliveries/services.py
+++ b/app/deliveries/services.py
@@ -316,7 +316,7 @@ class DeliveryService:
     # we would need, after the MVP, to optimize this
     # either by using postGIS to calculate the distance properly,
     # or by pre-calculating the distance between the delivery partner and the sellers and caching that in Redis, and then just fetching the available orders based on the cached distances
- @staticmethod
+@staticmethod
 def get_available_orders(user_id: str,search_radius: int = 3000,page: int = 1,per_page: int = 20,) -> dict:
     """Get available orders for the delivery partner with pagination.
     per_page is capped at 50.

--- a/app/deliveries/services.py
+++ b/app/deliveries/services.py
@@ -316,126 +316,136 @@ class DeliveryService:
     # we would need, after the MVP, to optimize this
     # either by using postGIS to calculate the distance properly,
     # or by pre-calculating the distance between the delivery partner and the sellers and caching that in Redis, and then just fetching the available orders based on the cached distances
-    @staticmethod
-    def get_available_orders(
-        user_id: str,
-        search_radius: int = 3000,
-        page: int = 1,
-        per_page: int = 20,
-    ) -> Dict:
-        """Get available orders for the delivery partner with pagination.
-        per_page is capped at 50.
-        """
-        per_page = min(max(1, per_page), 50)
-        page = max(1, page)
-        try:
-            with session_scope() as session:
+ @staticmethod
+def get_available_orders(user_id: str,search_radius: int = 3000,page: int = 1,per_page: int = 20,) -> dict:
+    """Get available orders for the delivery partner with pagination.
+    per_page is capped at 50.
+    """
+    per_page = min(max(1, per_page), 50)
+    page = max(1, page)
 
-                delivery_user = (
-                    session.query(DeliveryUser)
-                    .filter(DeliveryUser.id == user_id)
-                    .first()
+    try:
+        with session_scope() as session:
+            delivery_user = (
+                session.query(DeliveryUser)
+                .filter(DeliveryUser.id == user_id)
+                .first()
+            )
+
+            if (
+                not delivery_user
+                or not delivery_user.last_location
+                or delivery_user.last_location.latitude is None
+                or delivery_user.last_location.longitude is None
+            ):
+                raise NotFoundError("Delivery partner location not found")
+
+            delivery_lat = delivery_user.last_location.latitude
+            delivery_lng = delivery_user.last_location.longitude
+
+            orders = (
+                session.query(Order)
+                .filter(Order.status == OrderStatus.PROCESSING)
+                .options(
+                    joinedload(Order.shipping_address),
+                    joinedload(Order.items)
+                        .joinedload(OrderItem.seller)
+                        .joinedload(Seller.user)
+                        .joinedload(User.address),
+                )
+                .all()
+            )
+
+            available_orders = []
+
+            for order in orders:
+                dropoff = order.shipping_address
+
+                if (
+                    not dropoff
+                    or dropoff.latitude is None
+                    or dropoff.longitude is None
+                ):
+                    continue
+
+                if not order.items:
+                    continue
+
+                seller_pickups = []
+                pickup_distances = []
+                seen_seller_ids = set()
+
+                for item in order.items:
+                    seller = item.seller
+                    if not seller or seller.id in seen_seller_ids:
+                        continue
+
+                    seen_seller_ids.add(seller.id)
+
+                    seller_address = getattr(seller.user, "address", None) if seller.user else None
+
+                    if (
+                        not seller_address
+                        or seller_address.latitude is None
+                        or seller_address.longitude is None
+                    ):
+                        continue
+
+                    pickup_lat = seller_address.latitude
+                    pickup_lng = seller_address.longitude
+
+                    seller_pickups.append({"lat": pickup_lat, "lng": pickup_lng})
+
+                    distance = DeliveryService.haversine_distance(
+                        delivery_lat, delivery_lng, pickup_lat, pickup_lng
+                    )
+                    pickup_distances.append(distance)
+
+                if not seller_pickups:
+                    continue
+
+                # Better than average for multi-pickup feasibility
+                max_distance = max(pickup_distances)
+
+                if max_distance > search_radius:
+                    continue
+
+                estimated_earnings = (
+                    order.shipping_fee if order.shipping_fee is not None else 0
                 )
 
-                if not delivery_user or not delivery_user.last_location:
-                    raise NotFoundError("Delivery partner location not found")
-
-                delivery_lat = delivery_user.last_location.latitude
-                delivery_lng = delivery_user.last_location.longitude
-
-                orders = (
-                    session.query(Order)
-                    .join(ShippingAddress, Order.id == ShippingAddress.order_id)
-                    .join(OrderItem, Order.id == OrderItem.order_id)
-                    .join(Seller, OrderItem.seller_id == Seller.id)
-                    .join(User, Seller.user_id == User.id)
-                    .join(UserAddress, User.id == UserAddress.user_id)
-                    .filter(Order.status == OrderStatus.PROCESSING)
-                    .options(
-                        joinedload(Order.shipping_address),
-                        joinedload(Order.items).joinedload(OrderItem.seller),
-                    )
-                    .distinct()
-                    .all()
+                available_orders.append(
+                    {
+                        "order_id": order.id,
+                        "pickup": seller_pickups,
+                        "dropoff": {
+                            "lat": dropoff.latitude,
+                            "lng": dropoff.longitude,
+                        },
+                        "distance_meters": round(max_distance, 2),
+                        "estimated_earnings": estimated_earnings,
+                    }
                 )
-                # Filter by radius in Python (PostGIS can replace this later)
-                available_orders = []
 
-                for order in orders:
+            total = len(available_orders)
+            start = (page - 1) * per_page
+            end = start + per_page
+            page_orders = available_orders[start:end]
 
-                    seller_pickups = []
-                    total_distance = 0
+            return {
+                "range_meters": search_radius,
+                "orders": page_orders,
+                "page": page,
+                "per_page": per_page,
+                "total": total,
+                "total_pages": (total + per_page - 1) // per_page if total else 0,
+            }
 
-                    dropoff = order.shipping_address
-
-                    if not dropoff or dropoff.latitude is None:
-                        continue
-
-                    if not order.items:
-                        continue
-
-                    for item in order.items:
-                        seller = item.seller
-                        seller_address = (
-                            getattr(seller.user, "address", None) if seller else None
-                        )
-                        if (
-                            not seller_address
-                            or seller_address.latitude is None
-                            or seller_address.longitude is None
-                        ):
-                            continue
-
-                        pickup_lat = seller_address.latitude
-                        pickup_lng = seller_address.longitude
-
-                        seller_pickups.append({"lat": pickup_lat, "lng": pickup_lng})
-
-                        distance = DeliveryService.haversine_distance(
-                            delivery_lat, delivery_lng, pickup_lat, pickup_lng
-                        )
-
-                        total_distance += distance
-
-                    if not seller_pickups:
-                        continue
-
-                    average_distance = total_distance / len(seller_pickups)
-
-                    if average_distance > search_radius:
-                        continue
-
-                    drop_lat = dropoff.latitude
-                    drop_lng = dropoff.longitude
-
-                    estimated_earnings = order.shipping_fee or 0
-
-                    available_orders.append(
-                        {
-                            "order_id": order.id,
-                            "pickup": seller_pickups,
-                            "dropoff": {"lat": drop_lat, "lng": drop_lng},
-                            "distance_meters": round(average_distance, 2),
-                            "estimated_earnings": estimated_earnings,
-                        }
-                    )
-
-                total = len(available_orders)
-                start = (page - 1) * per_page
-                end = start + per_page
-                page_orders = available_orders[start:end]
-
-                return {
-                    "range_meters": search_radius,
-                    "orders": page_orders,
-                    "page": page,
-                    "per_page": per_page,
-                    "total": total,
-                    "total_pages": (total + per_page - 1) // per_page if total else 0,
-                }
-        except Exception as e:
-            logger.error(f"Error fetching available orders: {str(e)}")
-            raise NotFoundError("Failed to fetch available orders")
+    except NotFoundError:
+        raise
+    except Exception:
+        logger.exception("Error fetching available orders")
+        raise ServiceError("Failed to fetch available orders")
 
     @staticmethod
     def haversine_distance(lat1, lng1, lat2, lng2):

--- a/app/deliveries/services.py
+++ b/app/deliveries/services.py
@@ -317,7 +317,7 @@ class DeliveryService:
     # either by using postGIS to calculate the distance properly,
     # or by pre-calculating the distance between the delivery partner and the sellers and caching that in Redis, and then just fetching the available orders based on the cached distances
 @staticmethod
-def get_available_orders(user_id: str,search_radius: int = 3000,page: int = 1,per_page: int = 20,) -> dict:
+def get_available_orders(user_id: str, search_radius: int = 3000, page: int = 1, per_page: int = 20, ) -> dict:
     """Get available orders for the delivery partner with pagination.
     per_page is capped at 50.
     """
@@ -348,10 +348,12 @@ def get_available_orders(user_id: str,search_radius: int = 3000,page: int = 1,pe
                 .filter(Order.status == OrderStatus.PROCESSING)
                 .options(
                     joinedload(Order.shipping_address),
-                    joinedload(Order.items)
+                    (
+                        joinedload(Order.items)
                         .joinedload(OrderItem.seller)
                         .joinedload(Seller.user)
-                        .joinedload(User.address),
+                        .joinedload(User.address)
+                    ),
                 )
                 .all()
             )

--- a/app/deliveries/services.py
+++ b/app/deliveries/services.py
@@ -18,7 +18,7 @@ from sqlalchemy.orm import joinedload
 from external.redis import redis_client
 from app.libs.session import session_scope
 from app.libs.pagination import Paginator
-from app.libs.errors import NotFoundError, ValidationError
+from app.libs.errors import APIError, NotFoundError, ValidationError
 from app.libs.email_service import email_service
 
 # app imports
@@ -316,8 +316,15 @@ class DeliveryService:
     # we would need, after the MVP, to optimize this
     # either by using postGIS to calculate the distance properly,
     # or by pre-calculating the distance between the delivery partner and the sellers and caching that in Redis, and then just fetching the available orders based on the cached distances
+
+
 @staticmethod
-def get_available_orders(user_id: str, search_radius: int = 3000, page: int = 1, per_page: int = 20, ) -> dict:
+def get_available_orders(
+    user_id: str,
+    search_radius: int = 3000,
+    page: int = 1,
+    per_page: int = 20,
+) -> dict:
     """Get available orders for the delivery partner with pagination.
     per_page is capped at 50.
     """
@@ -327,18 +334,25 @@ def get_available_orders(user_id: str, search_radius: int = 3000, page: int = 1,
     try:
         with session_scope() as session:
             delivery_user = (
-                session.query(DeliveryUser)
-                .filter(DeliveryUser.id == user_id)
-                .first()
+                session.query(DeliveryUser).filter(DeliveryUser.id == user_id).first()
             )
 
+            if not delivery_user:
+                raise NotFoundError("Delivery partner not found")
+
             if (
-                not delivery_user
-                or not delivery_user.last_location
+                not delivery_user.last_location
                 or delivery_user.last_location.latitude is None
                 or delivery_user.last_location.longitude is None
             ):
-                raise NotFoundError("Delivery partner location not found")
+                return {
+                    "range_meters": search_radius,
+                    "orders": [],
+                    "page": page,
+                    "per_page": per_page,
+                    "total": 0,
+                    "total_pages": 0,
+                }
 
             delivery_lat = delivery_user.last_location.latitude
             delivery_lng = delivery_user.last_location.longitude
@@ -361,11 +375,7 @@ def get_available_orders(user_id: str, search_radius: int = 3000, page: int = 1,
             for order in orders:
                 dropoff = order.shipping_address
 
-                if (
-                    not dropoff
-                    or dropoff.latitude is None
-                    or dropoff.longitude is None
-                ):
+                if not dropoff or dropoff.latitude is None or dropoff.longitude is None:
                     continue
 
                 if not order.items:
@@ -382,7 +392,9 @@ def get_available_orders(user_id: str, search_radius: int = 3000, page: int = 1,
 
                     seen_seller_ids.add(seller.id)
 
-                    seller_address = getattr(seller.user, "address", None) if seller.user else None
+                    seller_address = (
+                        getattr(seller.user, "address", None) if seller.user else None
+                    )
 
                     if (
                         not seller_address
@@ -440,12 +452,11 @@ def get_available_orders(user_id: str, search_radius: int = 3000, page: int = 1,
                 "total": total,
                 "total_pages": (total + per_page - 1) // per_page if total else 0,
             }
-
     except NotFoundError:
         raise
-    except Exception:
-        logger.exception("Error fetching available orders")
-        raise ServiceError("Failed to fetch available orders")
+    except Exception as e:
+        logger.exception(f"Error fetching available orders {str(e)}")
+        raise APIError("Failed to fetch available orders", status_code=500)
 
     @staticmethod
     def haversine_distance(lat1, lng1, lat2, lng2):

--- a/app/deliveries/services.py
+++ b/app/deliveries/services.py
@@ -460,7 +460,9 @@ def get_available_orders(
         raise
     except SQLAlchemyError as e:
         logger.exception(f"Database error fetching available orders: {str(e)}")
-        raise APIError("Database error while fetching available orders", status_code=500)
+        raise APIError(
+            "Database error while fetching available orders", status_code=500
+        )
     except Exception as e:
         logger.exception(f"Unexpected error fetching available orders: {str(e)}")
         raise APIError("Failed to fetch available orders", status_code=500)

--- a/app/deliveries/services.py
+++ b/app/deliveries/services.py
@@ -195,11 +195,13 @@ class DeliveryService:
                     email=data.get("email"),
                     name=data["name"],
                     status=DeliveryStatus.INACTIVE,  # New partners start as INACTIVE until they complete onboarding
-                    vehicle_type=DeliveryVehicleType[data.get("vehicle_type").upper()]
-                    if data.get("vehicle_type")
-                    and data.get("vehicle_type").upper()
-                    in [e.name for e in DeliveryVehicleType]
-                    else DeliveryVehicleType.BIKE,
+                    vehicle_type=(
+                        DeliveryVehicleType[data.get("vehicle_type").upper()]
+                        if data.get("vehicle_type")
+                        and data.get("vehicle_type").upper()
+                        in [e.name for e in DeliveryVehicleType]
+                        else DeliveryVehicleType.BIKE
+                    ),
                 )
                 session.add(new_partner)
                 session.commit()
@@ -208,9 +210,11 @@ class DeliveryService:
                     "id": new_partner.id,
                     "name": new_partner.name,
                     "status": new_partner.status.value,
-                    "vehicle_type": new_partner.vehicle_type.value
-                    if new_partner.vehicle_type
-                    else None,
+                    "vehicle_type": (
+                        new_partner.vehicle_type.value
+                        if new_partner.vehicle_type
+                        else None
+                    ),
                 }
         except Exception as e:
             logger.error(f"Error registering delivery partner: {str(e)}")
@@ -232,9 +236,11 @@ class DeliveryService:
                     "id": delivery_user.id,
                     "name": delivery_user.name,
                     "status": delivery_user.status.value,
-                    "vehicle_type": delivery_user.vehicle_type.value
-                    if delivery_user.vehicle_type
-                    else None,
+                    "vehicle_type": (
+                        delivery_user.vehicle_type.value
+                        if delivery_user.vehicle_type
+                        else None
+                    ),
                     "rating": delivery_user.rating,
                 }
         except Exception as e:

--- a/app/orders/schemas.py
+++ b/app/orders/schemas.py
@@ -50,6 +50,7 @@ class BuyerOrderSchema(OrderCreateSchema):
     subtotal = fields.Float(dump_only=True)
     created_at = fields.DateTime(dump_only=True)
     items = fields.Nested(lambda: OrderItemSchema(many=True), dump_only=True)
+    shipping_address = fields.Dict(dump_only=True, attribute="shipping_address_dict")
 
 
 # For sellers - shows individual order items

--- a/app/payments/routes.py
+++ b/app/payments/routes.py
@@ -175,42 +175,46 @@ class PaymentInitialize(MethodView):
 @bp.route("/callback/<payment_id>")
 class PaymentCallback(MethodView):
     def get(self, payment_id):
-        """Handle payment callback from Paystack and redirect to frontend"""
+        """Handle payment callback from Paystack and redirect to the mobile app or web app"""
         from flask import redirect
+        from urllib.parse import urlencode
         from main.config import settings
+
+        # The platform is set on the callback_url when the payment was
+        # initialized (see PaymentService._initialize_paystack_transaction)
+        # and echoed back by Paystack's redirect.
+        platform = request.args.get("platform", "web")
+
+        def client_redirect(status: str, **params):
+            query_params = {k: v for k, v in params.items() if v is not None}
+            query = urlencode(query_params)
+            if platform == "mobile":
+                url = f"{settings.MOBILE_APP_SCHEME}payment/{status}"
+            else:
+                url = f"{settings.WEB_APP_BASE_URL}/payment-{status}"
+            return redirect(f"{url}?{query}" if query else url)
 
         try:
             # Get reference from query params
             reference = request.args.get("reference")
             if not reference:
-                # Redirect to frontend error page
-                frontend_url = settings.FRONTEND_BASE_URL or "http://localhost:3000"
-                return redirect(
-                    f"{frontend_url}/payment/failed?error=missing_reference"
-                )
+                return client_redirect("failed", error="missing_reference")
 
             # Verify payment
             verification_result = PaymentService.verify_payment(payment_id)
 
-            # Get frontend URL from config
-            frontend_url = settings.FRONTEND_BASE_URL or "http://localhost:3000"
-
             if verification_result["verified"]:
-                # Redirect to frontend success page
-                return redirect(
-                    f"{frontend_url}/payment/success?payment_id={payment_id}&reference={reference}"
+                return client_redirect(
+                    "success", payment_id=payment_id, reference=reference
                 )
             else:
-                # Redirect to frontend failure page
-                return redirect(
-                    f"{frontend_url}/payment/failed?payment_id={payment_id}&reference={reference}"
+                return client_redirect(
+                    "failed", payment_id=payment_id, reference=reference
                 )
 
         except Exception as e:
             current_app.logger.error(f"Payment callback error: {str(e)}")
-            # Redirect to frontend error page
-            frontend_url = settings.FRONTEND_BASE_URL or "http://localhost:3000"
-            return redirect(f"{frontend_url}/payment/failed?error=server_error")
+            return client_redirect("failed", error="server_error")
 
 
 # Admin routes for payment management

--- a/app/payments/services.py
+++ b/app/payments/services.py
@@ -370,7 +370,14 @@ class PaymentService:
                 except:
                     base_url = "http://localhost:8000"  # Final fallback
 
-            callback_url = f"{base_url}/api/v1/payments/callback/{payment.id}"
+            # Carry the originating platform through Paystack's redirect so the
+            # final callback knows whether to send the user back to the mobile
+            # app (deep link) or the web app.
+            platform = (metadata or {}).get("platform", "web")
+            callback_url = (
+                f"{base_url}/api/v1/payments/callback/{payment.id}"
+                f"?platform={platform}"
+            )
 
             payload = {
                 "amount": int(payment.amount * 100),  # Convert to kobo

--- a/main/config.py
+++ b/main/config.py
@@ -73,13 +73,18 @@ class Config:
             default="http://localhost:8000" if self.ENV == "development" else "",
         )
 
-        # Frontend Base URL for payment redirects
-        # For production: https://yourdomain.com or https://app.yourdomain.com
+        # Web app base URL for payment redirects
+        # For production: https://marktcommerce.com/app
         # For development: http://localhost:3000
-        self.FRONTEND_BASE_URL = config(
-            "FRONTEND_BASE_URL",
-            default="http://localhost:3000" if self.ENV == "development" else "",
+        self.WEB_APP_BASE_URL = config(
+            "WEB_APP_BASE_URL",
+            default="http://localhost:3000"
+            if self.ENV == "development"
+            else "https://marktcommerce.com/app",
         )
+
+        # Mobile app deep link scheme for payment redirects (e.g. markt://)
+        self.MOBILE_APP_SCHEME = config("MOBILE_APP_SCHEME", default="markt://")
 
         # AWS Configuration
         self.AWS_ACCESS_KEY = config("AWS_ACCESS_KEY", default="")

--- a/migrations/versions/a1b2c3d4e5f6_fix_orders_add_ready_for_delivery_status.py
+++ b/migrations/versions/a1b2c3d4e5f6_fix_orders_add_ready_for_delivery_status.py
@@ -1,0 +1,39 @@
+"""fix(orders): add READY_FOR_DELIVERY to orderstatus enum
+
+Revision ID: a1b2c3d4e5f6
+Revises: fef026f03f06
+Create Date: 2026-06-02 00:00:00.000000
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'a1b2c3d4e5f6'
+down_revision = 'fef026f03f06'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # ALTER TYPE ... ADD VALUE cannot run inside a transaction block in PostgreSQL
+    op.execute("ALTER TYPE orderstatus ADD VALUE IF NOT EXISTS 'READY_FOR_DELIVERY'")
+
+
+def downgrade():
+    # PostgreSQL does not support removing an enum value natively.
+    # The safest approach is to recreate the enum without the value and cast existing rows.
+    op.execute(
+        "ALTER TABLE orders ALTER COLUMN status TYPE VARCHAR(50) "
+        "USING status::text"
+    )
+    op.execute("DROP TYPE orderstatus")
+    op.execute(
+        "CREATE TYPE orderstatus AS ENUM ("
+        "'PENDING_PAYMENT', 'PENDING', 'PROCESSING', 'SHIPPED', "
+        "'DELIVERED', 'CANCELLED', 'RETURNED', 'FAILED'"
+        ")"
+    )
+    op.execute(
+        "ALTER TABLE orders ALTER COLUMN status TYPE orderstatus "
+        "USING status::orderstatus"
+    )

--- a/settings.ini.example
+++ b/settings.ini.example
@@ -51,10 +51,13 @@ PAYMENT_GATEWAY=paystack
 # Production: https://api.yourdomain.com
 API_BASE_URL=http://localhost:8000
 
-# Frontend URL (where users are redirected after payment)
+# Web app URL (where browser/web users are redirected after payment)
 # Development: http://localhost:3000
-# Production: https://yourdomain.com or https://app.yourdomain.com
-FRONTEND_BASE_URL=http://localhost:3000
+# Production: https://marktcommerce.com/app
+WEB_APP_BASE_URL=http://localhost:3000
+
+# Mobile app deep link scheme (where mobile app users are redirected after payment)
+MOBILE_APP_SCHEME=markt://
 
 # AWS Configuration
 AWS_ACCESS_KEY=your_aws_access_key_here


### PR DESCRIPTION
## Description
Paystack's checkout callback was redirecting every user to a single hardcoded
`FRONTEND_BASE_URL` (defaulting to `http://localhost:3000`), which caused
`ERR_CONNECTION_REFUSED` for any client where that wasn't actually running
(e.g. a mobile webview). The callback now distinguishes mobile vs. web
clients and redirects accordingly:
- Mobile to `markt://payment/success` or `markt://payment/failed` (deep link)
- Web to `https://marktcommerce.com/app/payment-success` or `-failed`

The originating platform is passed by the client as `metadata.platform`
(`"mobile"` or `"web"`) on `POST /payments/initialize` (or `/create`), threaded
through the Paystack `callback_url` as a query param, and read back by
`PaymentCallback.get` to pick the redirect target. `FRONTEND_BASE_URL` is
replaced by `WEB_APP_BASE_URL` + `MOBILE_APP_SCHEME` in config.

## Tickets
Ticket ID [link]

## Related Issue
Fixes #[Issue number]

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?
[Attach the UNIT TEST coverage report]

Manually traced the request flow (initialize → Paystack → callback) and
verified the redirect URLs are built correctly for both `platform=mobile`
and `platform=web` against the new config defaults. No automated tests were
added — flagging this in case it's required before merge.

## Tested & Approved by?
[QA Engineer]

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
`FRONTEND_BASE_URL` was removed entirely (only consumer was this callback
route) in favor of `WEB_APP_BASE_URL` + `MOBILE_APP_SCHEME`. Mobile/web
clients calling `/payments/initialize` need to pass `metadata: {"platform":
"mobile"}` going forward — defaults to `"web"` if omitted, so existing web
clients are unaffected.

Separately noticed (not fixed in this PR): the Paystack `reference` is
double-prefixed (`PAY_PAY_XXXXXXXX`) because `payment.id` possibly already includes
the `PAY_` prefix before `services.py` prepends another one. Self-consistent,
just slightly off, worth a follow-up.
