### PR TITLE
feat(payments): enhance payment callback handling for mobile and web …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,3 +68,6 @@ jobs:
 
       - name: Syntax smoke check
         run: python -m compileall -q app main external
+
+      - name: Run pytest
+        run: pytest tests/ -v --tb=short

--- a/app/cart/routes.py
+++ b/app/cart/routes.py
@@ -15,6 +15,7 @@ from .schemas import (
     AddToCartSchema,
     UpdateCartItemSchema,
     CheckoutSchema,
+    CheckoutResponseSchema,
     CartSummarySchema,
 )
 
@@ -99,7 +100,7 @@ class Checkout(MethodView):
     @login_required
     @buyer_required
     @bp.arguments(CheckoutSchema)
-    @bp.response(201)
+    @bp.response(201, CheckoutResponseSchema)
     def post(self, checkout_data):
         """Checkout cart and create order"""
         try:
@@ -108,7 +109,18 @@ class Checkout(MethodView):
                 checkout_data,
                 idempotency_key=checkout_data.get("idempotency_key"),
             )
-            return {"order_id": order.id, "message": "Order created successfully"}
+            return {
+                "order_id": order.id,
+                "order_number": order.order_number,
+                "status": order.status.value,
+                "subtotal": order.subtotal,
+                "shipping_fee": order.shipping_fee,
+                "tax": order.tax,
+                "discount": order.discount,
+                "total": order.total,
+                "shipping_address": order.shipping_address_dict,
+                "message": "Order created successfully",
+            }
         except APIError as e:
             abort(e.status_code, message=e.message)
 

--- a/app/cart/schemas.py
+++ b/app/cart/schemas.py
@@ -52,9 +52,25 @@ class CheckoutSchema(Schema):
     shipping_address = fields.Dict(required=True)
     billing_address = fields.Dict(required=True)
     notes = fields.Str(allow_none=True)
+    use_saved_address = fields.Bool(missing=False)
     idempotency_key = fields.Str(
         allow_none=True
     )  # Optional idempotency key for retry safety
+
+
+class CheckoutResponseSchema(Schema):
+    """Full order summary returned after checkout."""
+
+    order_id = fields.Str(required=True)
+    order_number = fields.Str(allow_none=True)
+    status = fields.Str(required=True)
+    subtotal = fields.Float(required=True)
+    shipping_fee = fields.Float(required=True)
+    tax = fields.Float(required=True)
+    discount = fields.Float(required=True)
+    total = fields.Float(required=True)
+    shipping_address = fields.Dict(required=True)
+    message = fields.Str()
 
 
 class CartSummarySchema(Schema):

--- a/app/cart/services.py
+++ b/app/cart/services.py
@@ -25,6 +25,10 @@ from .models import Cart, CartItem
 from app.users.models import User, Buyer
 from app.products.models import Product, ProductVariant
 from app.orders.models import Order, OrderItem, OrderStatus, ShippingAddress
+from app.orders.shipping import (
+    normalize_shipping_address,
+    shipping_address_to_model_kwargs,
+)
 from app.notifications.services import NotificationService
 from app.notifications.models import NotificationType
 
@@ -316,14 +320,18 @@ class CartService:
             # Validate cart items (check availability, prices, etc.)
             CartService._validate_cart_items(cart.items)
 
+            shipping_normalized = normalize_shipping_address(
+                checkout_data.get("shipping_address"),
+                saved_address=user.buyer_account.shipping_address,
+                use_saved_address=checkout_data.get("use_saved_address", False),
+            )
+
             # Calculate order totals
             subtotal = cart.subtotal()
             shipping_fee = CartService._calculate_shipping_fee(
-                cart, checkout_data.get("shipping_address")
+                cart, shipping_normalized
             )
-            tax = CartService._calculate_tax(
-                subtotal, checkout_data.get("shipping_address")
-            )
+            tax = CartService._calculate_tax(subtotal, shipping_normalized)
             discount = CartService._calculate_discount(subtotal, cart.coupon_code)
             total = subtotal + shipping_fee + tax - discount
 
@@ -339,21 +347,9 @@ class CartService:
             order.discount = discount
             order.total = total
 
-            # shipping_address is a relationship; map dict payload to ShippingAddress ORM
-            shipping_data = checkout_data.get("shipping_address") or {}
-            shipping_address = ShippingAddress(
-                recipient_name=shipping_data.get("recipient_name"),
-                street_address=shipping_data.get("street_address")
-                or shipping_data.get("street"),
-                city=shipping_data.get("city"),
-                state=shipping_data.get("state"),
-                postal_code=shipping_data.get("postal_code")
-                or shipping_data.get("zip"),
-                country=shipping_data.get("country"),
-                latitude=shipping_data.get("latitude"),
-                longitude=shipping_data.get("longitude"),
+            order.shipping_address = ShippingAddress(
+                **shipping_address_to_model_kwargs(shipping_normalized)
             )
-            order.shipping_address = shipping_address
 
             # billing_address is JSONB on Order, so we can store the dict directly
             order.billing_address = checkout_data.get("billing_address")
@@ -361,6 +357,7 @@ class CartService:
             order.idempotency_key = idempotency_key or str(uuid.uuid4())
             session.add(order)
             session.flush()
+            order.order_number = order.generate_order_number()
 
             # Create order items from cart items
             for cart_item in cart.items:

--- a/app/chats/services.py
+++ b/app/chats/services.py
@@ -144,16 +144,56 @@ class ChatService:
         return result
 
     @staticmethod
+    def _user_pair_room_filter(buyer_id: str, seller_id: str):
+        """Match a chat room regardless of which user is stored as buyer or seller."""
+        return db.or_(
+            db.and_(
+                ChatRoom.buyer_id == buyer_id,
+                ChatRoom.seller_id == seller_id,
+            ),
+            db.and_(
+                ChatRoom.buyer_id == seller_id,
+                ChatRoom.seller_id == buyer_id,
+            ),
+        )
+
+    @staticmethod
+    def _find_room_for_user_pair(session, buyer_id: str, seller_id: str):
+        """Return the most recently active room between two users, if any."""
+        return (
+            session.query(ChatRoom)
+            .filter(ChatService._user_pair_room_filter(buyer_id, seller_id))
+            .order_by(
+                ChatRoom.last_message_at.desc().nullslast(),
+                ChatRoom.id.desc(),
+            )
+            .first()
+        )
+
+    @staticmethod
+    def _apply_room_context(
+        room: ChatRoom,
+        product_id: Optional[str],
+        request_id: Optional[str],
+    ) -> None:
+        """Attach product/request context to a room when not already set."""
+        if product_id and room.product_id is None:
+            room.product_id = product_id
+        if request_id and room.request_id is None:
+            room.request_id = request_id
+
+    @staticmethod
     def create_or_get_chat_room(
         buyer_id: str,
         seller_id: str,
         product_id: Optional[str] = None,
         request_id: Optional[str] = None,
     ) -> ChatRoom:
-        """Create or get existing chat room between buyer and seller
+        """Create or get the single chat room between a buyer and seller.
 
-        This method ensures that only one chat room exists between two users
-        for a given product/request, regardless of which user initiated the conversation.
+        One conversation exists per user pair. product_id and request_id are
+        optional context (e.g. opened from a product page) and do not create
+        separate rooms. Product-specific content belongs on messages.
         """
         try:
             if buyer_id == seller_id:
@@ -184,31 +224,15 @@ class ChatService:
                     if not request_obj:
                         raise NotFoundError(f"Request with ID {request_id} not found")
 
-                # Check if room already exists in either direction
-                # (buyer_id=A, seller_id=B) OR (buyer_id=B, seller_id=A)
-                existing_room = (
-                    session.query(ChatRoom)
-                    .filter(
-                        db.or_(
-                            db.and_(
-                                ChatRoom.buyer_id == buyer_id,
-                                ChatRoom.seller_id == seller_id,
-                            ),
-                            db.and_(
-                                ChatRoom.buyer_id == seller_id,
-                                ChatRoom.seller_id == buyer_id,
-                            ),
-                        ),
-                        ChatRoom.product_id == product_id,
-                        ChatRoom.request_id == request_id,
-                    )
-                    .first()
+                existing_room = ChatService._find_room_for_user_pair(
+                    session, buyer_id, seller_id
                 )
-
                 if existing_room:
+                    ChatService._apply_room_context(
+                        existing_room, product_id, request_id
+                    )
                     return existing_room
 
-                # Create new room
                 room = ChatRoom(
                     buyer_id=buyer_id,
                     seller_id=seller_id,
@@ -219,7 +243,6 @@ class ChatService:
                 session.add(room)
                 session.flush()
 
-                # Cache room for both users
                 ChatService._cache_user_room(buyer_id, room)
                 ChatService._cache_user_room(seller_id, room)
 

--- a/app/orders/models.py
+++ b/app/orders/models.py
@@ -36,6 +36,8 @@ class Order(BaseModel, UniqueIdMixin):
     idempotency_key = db.Column(
         db.String(100), unique=True, nullable=True
     )  # Prevent duplicate orders
+    cancelled_at = db.Column(db.DateTime, nullable=True)
+    cancel_reason = db.Column(db.Text, nullable=True)
     # Relationships
     buyer = db.relationship("Buyer", back_populates="orders")
     items = db.relationship(

--- a/app/orders/models.py
+++ b/app/orders/models.py
@@ -38,6 +38,7 @@ class Order(BaseModel, UniqueIdMixin):
     )  # Prevent duplicate orders
     cancelled_at = db.Column(db.DateTime, nullable=True)
     cancel_reason = db.Column(db.Text, nullable=True)
+    paystack_split_used = db.Column(db.Boolean, default=False, nullable=False)
     # Relationships
     buyer = db.relationship("Buyer", back_populates="orders")
     items = db.relationship(
@@ -51,6 +52,7 @@ class Order(BaseModel, UniqueIdMixin):
         cascade="all, delete-orphan",
     )
     shipments = db.relationship("Shipment", back_populates="order")
+    returns = db.relationship("OrderReturn", back_populates="order", lazy="dynamic")
 
     def generate_order_number(self):
         # Implement your order number generation logic
@@ -133,3 +135,28 @@ class Shipment(BaseModel):
     delivered_at = db.Column(db.DateTime)
 
     order = db.relationship("Order", back_populates="shipments")
+
+
+class OrderReturnStatus(Enum):
+    REQUESTED = "requested"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+    REFUNDED = "refunded"
+
+
+class OrderReturn(BaseModel, UniqueIdMixin):
+    __tablename__ = "order_returns"
+    id_prefix = "RET_"
+
+    id = db.Column(db.String(12), primary_key=True, default=None)
+    order_id = db.Column(db.String(12), db.ForeignKey("orders.id"), nullable=False)
+    buyer_id = db.Column(db.Integer, db.ForeignKey("buyers.id"), nullable=False)
+    reason = db.Column(db.Text, nullable=False)
+    status = db.Column(
+        db.Enum(OrderReturnStatus), default=OrderReturnStatus.REQUESTED, nullable=False
+    )
+    refund_amount = db.Column(db.Float, nullable=True)
+    seller_notes = db.Column(db.Text, nullable=True)
+
+    order = db.relationship("Order", back_populates="returns")
+    buyer = db.relationship("Buyer")

--- a/app/orders/routes.py
+++ b/app/orders/routes.py
@@ -2,6 +2,7 @@
 from flask_smorest import Blueprint, abort
 from flask.views import MethodView
 from flask_login import login_required, current_user
+from flask import jsonify, make_response
 
 # project imports
 from app.libs.schemas import PaginationQueryArgs
@@ -35,16 +36,25 @@ class OrderList(MethodView):
         return OrderService.get_user_orders(current_user.buyer_account.id)
 
     @login_required
+    @buyer_required
     @bp.arguments(OrderCreateSchema)
-    @bp.response(201, OrderSchema)
     def post(self, order_data):
-        """Create new order from cart"""
-        return OrderService.create_order(
-            order_data["cart_id"],
-            current_user.buyer_account.id,
-            order_data["shipping_address"],
-            order_data.get("payment_method", "card"),
+        """Create new order from cart (deprecated — use POST /cart/checkout)."""
+        response = make_response(
+            jsonify(
+                {
+                    "message": (
+                        "POST /orders is deprecated. "
+                        "Use POST /cart/checkout to create an order from the active cart."
+                    ),
+                    "replacement": "/api/v1/cart/checkout",
+                }
+            ),
+            410,
         )
+        response.headers["Deprecation"] = "true"
+        response.headers["Link"] = '</api/v1/cart/checkout>; rel="successor-version"'
+        return response
 
 
 @bp.route("/<order_id>/pay")

--- a/app/orders/routes.py
+++ b/app/orders/routes.py
@@ -7,6 +7,7 @@ from flask import jsonify, make_response
 # project imports
 from app.libs.schemas import PaginationQueryArgs
 from app.libs.decorators import seller_required, buyer_required
+from app.libs.errors import APIError
 from app.payments.schemas import PaymentSchema
 
 # app imports
@@ -21,6 +22,8 @@ from .schemas import (
     SellerOrderResponseSchema,
     BuyerOrderSchema,
     OrderItemStatusUpdateSchema,
+    OrderCancelSchema,
+    OrderCancelResponseSchema,
 )
 
 bp = Blueprint("orders", __name__, description="Order operations", url_prefix="/orders")
@@ -125,10 +128,43 @@ class TrackOrder(MethodView):
     @login_required
     @bp.response(200, TrackingSchema)
     def get(self, order_id):
-        """Track order status"""
-        # TODO: Real-time shipping updates
-        # TODO: Delivery estimation
-        # TODO: Map integration
+        """Track order status and delivery progress"""
+        try:
+            return OrderService.track_order(order_id, current_user.id)
+        except APIError as e:
+            abort(e.status_code, message=e.message)
+
+
+@bp.route("/<order_id>/cancel")
+class CancelOrder(MethodView):
+    @login_required
+    @buyer_required
+    @bp.arguments(OrderCancelSchema)
+    @bp.response(200, OrderCancelResponseSchema)
+    def post(self, cancel_data, order_id):
+        """Cancel an order (buyer only, before shipment)"""
+        try:
+            order = OrderService.cancel_order(
+                order_id,
+                current_user.buyer_account.id,
+                reason=cancel_data.get("reason"),
+            )
+            from app.payments.models import PaymentStatus
+
+            refund_amount = 0.0
+            for payment in order.payments or []:
+                if payment.status == PaymentStatus.REFUNDED:
+                    refund_amount = payment.amount
+                    break
+            return {
+                "order_id": order.id,
+                "status": order.status.value,
+                "cancelled_at": order.cancelled_at,
+                "cancel_reason": order.cancel_reason,
+                "refund_amount": refund_amount,
+            }
+        except APIError as e:
+            abort(e.status_code, message=e.message)
 
 
 @bp.route("/<order_id>/review")

--- a/app/orders/routes.py
+++ b/app/orders/routes.py
@@ -24,6 +24,9 @@ from .schemas import (
     OrderItemStatusUpdateSchema,
     OrderCancelSchema,
     OrderCancelResponseSchema,
+    OrderReturnRequestSchema,
+    OrderReturnResponseSchema,
+    OrderReturnActionSchema,
 )
 
 bp = Blueprint("orders", __name__, description="Order operations", url_prefix="/orders")
@@ -163,6 +166,60 @@ class CancelOrder(MethodView):
                 "cancel_reason": order.cancel_reason,
                 "refund_amount": refund_amount,
             }
+        except APIError as e:
+            abort(e.status_code, message=e.message)
+
+
+@bp.route("/<order_id>/returns")
+class OrderReturnRequest(MethodView):
+    @login_required
+    @buyer_required
+    @bp.arguments(OrderReturnRequestSchema)
+    @bp.response(201, OrderReturnResponseSchema)
+    def post(self, return_data, order_id):
+        """Request a return for a shipped or delivered order"""
+        try:
+            return OrderService.request_return(
+                order_id,
+                current_user.buyer_account.id,
+                reason=return_data["reason"],
+            )
+        except APIError as e:
+            abort(e.status_code, message=e.message)
+
+
+@bp.route("/returns/<return_id>/approve")
+class ApproveOrderReturn(MethodView):
+    @login_required
+    @seller_required
+    @bp.arguments(OrderReturnActionSchema)
+    @bp.response(200, OrderReturnResponseSchema)
+    def post(self, action_data, return_id):
+        """Approve a buyer return request and refund to wallet"""
+        try:
+            return OrderService.approve_return(
+                return_id,
+                current_user.seller_account.id,
+                seller_notes=action_data.get("seller_notes"),
+            )
+        except APIError as e:
+            abort(e.status_code, message=e.message)
+
+
+@bp.route("/returns/<return_id>/reject")
+class RejectOrderReturn(MethodView):
+    @login_required
+    @seller_required
+    @bp.arguments(OrderReturnActionSchema)
+    @bp.response(200, OrderReturnResponseSchema)
+    def post(self, action_data, return_id):
+        """Reject a buyer return request"""
+        try:
+            return OrderService.reject_return(
+                return_id,
+                current_user.seller_account.id,
+                seller_notes=action_data.get("seller_notes"),
+            )
         except APIError as e:
             abort(e.status_code, message=e.message)
 

--- a/app/orders/schemas.py
+++ b/app/orders/schemas.py
@@ -79,7 +79,26 @@ class SellerOrderResponseSchema(Schema):
 
 
 class TrackingSchema(Schema):
-    pass
+    order_id = fields.Str()
+    order_number = fields.Str(allow_none=True)
+    status = fields.Str()
+    timeline = fields.List(fields.Dict())
+    shipping_address = fields.Dict(allow_none=True)
+    items = fields.List(fields.Dict())
+    shipment = fields.Dict(allow_none=True)
+    delivery = fields.Dict(allow_none=True)
+
+
+class OrderCancelSchema(Schema):
+    reason = fields.Str(allow_none=True)
+
+
+class OrderCancelResponseSchema(Schema):
+    order_id = fields.Str()
+    status = fields.Str()
+    cancelled_at = fields.DateTime(allow_none=True)
+    cancel_reason = fields.Str(allow_none=True)
+    refund_amount = fields.Float()
 
 
 class OrderItemStatusUpdateSchema(Schema):

--- a/app/orders/schemas.py
+++ b/app/orders/schemas.py
@@ -101,6 +101,24 @@ class OrderCancelResponseSchema(Schema):
     refund_amount = fields.Float()
 
 
+class OrderReturnRequestSchema(Schema):
+    reason = fields.Str(required=True, validate=validate.Length(min=3))
+
+
+class OrderReturnResponseSchema(Schema):
+    id = fields.Str()
+    order_id = fields.Str()
+    status = fields.Str()
+    reason = fields.Str()
+    refund_amount = fields.Float(allow_none=True)
+    seller_notes = fields.Str(allow_none=True)
+    created_at = fields.DateTime()
+
+
+class OrderReturnActionSchema(Schema):
+    seller_notes = fields.Str(allow_none=True)
+
+
 class OrderItemStatusUpdateSchema(Schema):
     status = fields.Enum(OrderItem.Status, by_value=True, required=True)
 

--- a/app/orders/services.py
+++ b/app/orders/services.py
@@ -1,7 +1,7 @@
 # python imports
 from datetime import datetime, timedelta
 import logging
-import requests
+from typing import Any, Dict, Optional
 
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -21,9 +21,10 @@ from app.cart.models import Cart, CartItem
 from app.products.models import Product
 from app.payments.models import Payment, PaymentStatus
 from app.users.models import Buyer
+from app.products.services import ProductService
 
 # app imports
-from .models import Order, OrderStatus, OrderItem, ShippingAddress
+from .models import Order, OrderStatus, OrderItem, ShippingAddress, Shipment
 from app.orders.shipping import (
     normalize_shipping_address,
     shipping_address_to_model_kwargs,
@@ -31,6 +32,13 @@ from app.orders.shipping import (
 
 
 logger = logging.getLogger(__name__)
+
+BUYER_CANCELLABLE_STATUSES = {
+    OrderStatus.PENDING_PAYMENT,
+    OrderStatus.PENDING,
+    OrderStatus.PROCESSING,
+    OrderStatus.READY_FOR_DELIVERY,
+}
 
 
 class OrderService:
@@ -201,6 +209,213 @@ class OrderService:
 
             return order
 
+    @staticmethod
+    def _get_completed_payment_amount(order: Order) -> float:
+        for payment in order.payments or []:
+            if payment.status == PaymentStatus.COMPLETED:
+                return payment.amount
+        return 0.0
+
+    @staticmethod
+    def cancel_order(order_id: str, buyer_id: int, reason: Optional[str] = None):
+        """Cancel an order on behalf of the buyer."""
+        from app.wallet.services import WalletService
+
+        paid_amount = 0.0
+        buyer_user_id = None
+        order_items = []
+
+        with session_scope() as session:
+            order = (
+                session.query(Order)
+                .options(
+                    db.joinedload(Order.items),
+                    db.joinedload(Order.payments),
+                    db.joinedload(Order.buyer),
+                )
+                .get(order_id)
+            )
+
+            if not order:
+                raise NotFoundError("Order not found")
+            if order.buyer_id != buyer_id:
+                raise ForbiddenError("You can only cancel your own orders")
+            if order.status == OrderStatus.CANCELLED:
+                raise ConflictError("Order is already cancelled")
+            if order.status not in BUYER_CANCELLABLE_STATUSES:
+                raise ValidationError(
+                    f"Order in status '{order.status.value}' cannot be cancelled"
+                )
+
+            paid_amount = OrderService._get_completed_payment_amount(order)
+            buyer_user_id = order.buyer.user_id if order.buyer else None
+            order_items = list(order.items)
+
+            order.status = OrderStatus.CANCELLED
+            order.cancelled_at = datetime.utcnow()
+            order.cancel_reason = reason
+
+            for item in order.items:
+                if item.status != OrderItem.Status.CANCELLED:
+                    item.status = OrderItem.Status.CANCELLED
+
+            if paid_amount > 0:
+                for payment in order.payments:
+                    if payment.status == PaymentStatus.COMPLETED:
+                        payment.status = PaymentStatus.REFUNDED
+
+            session.flush()
+
+        if paid_amount > 0:
+            ProductService.restore_inventory_for_order(order_items)
+            if buyer_user_id:
+                WalletService.refund_order_to_wallet(
+                    buyer_user_id, order_id, paid_amount
+                )
+
+        try:
+            from app.realtime.event_manager import EventManager
+
+            EventManager.emit_to_order(
+                order_id,
+                "order_status_changed",
+                {
+                    "order_id": order_id,
+                    "user_id": buyer_user_id,
+                    "status": OrderStatus.CANCELLED.value,
+                    "metadata": {"cancel_reason": reason},
+                },
+            )
+        except Exception as e:
+            logger.warning(f"Failed to queue order_status_changed event: {e}")
+
+        return OrderService.get_order(order_id)
+
+    @staticmethod
+    def track_order(order_id: str, user_id: str) -> Dict[str, Any]:
+        """Return order tracking timeline for buyer or participating seller."""
+        from app.deliveries.models import DeliveryOrderAssignment, AssignmentStatus
+
+        with session_scope() as session:
+            order = (
+                session.query(Order)
+                .options(
+                    db.joinedload(Order.items).joinedload(OrderItem.seller),
+                    db.joinedload(Order.shipping_address),
+                    db.joinedload(Order.shipments),
+                    db.joinedload(Order.payments),
+                    db.joinedload(Order.buyer),
+                )
+                .get(order_id)
+            )
+
+            if not order:
+                raise NotFoundError("Order not found")
+
+            is_buyer = order.buyer and order.buyer.user_id == user_id
+            is_seller = any(
+                item.seller and item.seller.user_id == user_id for item in order.items
+            )
+            if not is_buyer and not is_seller:
+                raise ForbiddenError("You do not have access to track this order")
+
+            assignment = (
+                session.query(DeliveryOrderAssignment)
+                .filter_by(order_id=order_id)
+                .order_by(DeliveryOrderAssignment.assigned_at.desc())
+                .first()
+            )
+
+            latest_payment = None
+            for payment in sorted(
+                order.payments or [], key=lambda p: p.created_at or datetime.min
+            ):
+                if payment.status == PaymentStatus.COMPLETED:
+                    latest_payment = payment
+
+            timeline = [
+                {
+                    "status": "created",
+                    "label": "Order placed",
+                    "timestamp": order.created_at.isoformat()
+                    if order.created_at
+                    else None,
+                }
+            ]
+            if latest_payment and latest_payment.paid_at:
+                timeline.append(
+                    {
+                        "status": "paid",
+                        "label": "Payment confirmed",
+                        "timestamp": latest_payment.paid_at.isoformat(),
+                    }
+                )
+            if order.cancelled_at:
+                timeline.append(
+                    {
+                        "status": "cancelled",
+                        "label": "Order cancelled",
+                        "timestamp": order.cancelled_at.isoformat(),
+                    }
+                )
+            elif order.status == OrderStatus.DELIVERED:
+                timeline.append(
+                    {
+                        "status": "delivered",
+                        "label": "Delivered",
+                        "timestamp": order.updated_at.isoformat()
+                        if order.updated_at
+                        else None,
+                    }
+                )
+
+            shipment = order.shipments[0] if order.shipments else None
+            delivery_info = None
+            if assignment and assignment.status == AssignmentStatus.ACCEPTED:
+                delivery_info = {
+                    "assignment_id": assignment.assignment_id,
+                    "status": assignment.status.value,
+                    "logistical_status": assignment.logistical_status.value
+                    if assignment.logistical_status
+                    else None,
+                    "assigned_at": assignment.assigned_at.isoformat()
+                    if assignment.assigned_at
+                    else None,
+                }
+
+            return {
+                "order_id": order.id,
+                "order_number": order.order_number,
+                "status": order.status.value,
+                "timeline": timeline,
+                "shipping_address": order.shipping_address_dict,
+                "items": [
+                    {
+                        "id": item.id,
+                        "product_id": item.product_id,
+                        "quantity": item.quantity,
+                        "status": item.status.value,
+                        "seller_id": item.seller_id,
+                    }
+                    for item in order.items
+                ],
+                "shipment": {
+                    "carrier": shipment.carrier,
+                    "tracking_number": shipment.tracking_number,
+                    "tracking_url": shipment.tracking_url,
+                    "status": shipment.status,
+                    "shipped_at": shipment.shipped_at.isoformat()
+                    if shipment and shipment.shipped_at
+                    else None,
+                    "delivered_at": shipment.delivered_at.isoformat()
+                    if shipment and shipment.delivered_at
+                    else None,
+                }
+                if shipment
+                else None,
+                "delivery": delivery_info,
+            }
+
     # TODO: Add order history tracking
     # TODO: Add refund processing
 
@@ -241,6 +456,7 @@ class SellerOrderService:
         with session_scope() as session:
             item = (
                 session.query(OrderItem)
+                .options(db.joinedload(OrderItem.seller))
                 .filter_by(id=order_item_id, seller_id=seller_id)
                 .first()
             )
@@ -269,11 +485,14 @@ class SellerOrderService:
 
             item.status = status
 
-            # If all items are delivered, mark order as completed
             if status == OrderItem.Status.DELIVERED:
                 order = session.query(Order).get(item.order_id)
                 if all(i.status == OrderItem.Status.DELIVERED for i in order.items):
                     order.status = OrderStatus.DELIVERED
+
+                from app.wallet.services import WalletService
+
+                WalletService.settle_order_item(item)
 
             return item
 

--- a/app/orders/services.py
+++ b/app/orders/services.py
@@ -24,7 +24,15 @@ from app.users.models import Buyer
 from app.products.services import ProductService
 
 # app imports
-from .models import Order, OrderStatus, OrderItem, ShippingAddress, Shipment
+from .models import (
+    Order,
+    OrderStatus,
+    OrderItem,
+    ShippingAddress,
+    Shipment,
+    OrderReturn,
+    OrderReturnStatus,
+)
 from app.orders.shipping import (
     normalize_shipping_address,
     shipping_address_to_model_kwargs,
@@ -38,6 +46,11 @@ BUYER_CANCELLABLE_STATUSES = {
     OrderStatus.PENDING,
     OrderStatus.PROCESSING,
     OrderStatus.READY_FOR_DELIVERY,
+}
+
+RETURNABLE_ORDER_STATUSES = {
+    OrderStatus.SHIPPED,
+    OrderStatus.DELIVERED,
 }
 
 
@@ -415,6 +428,146 @@ class OrderService:
                 else None,
                 "delivery": delivery_info,
             }
+
+    @staticmethod
+    def request_return(order_id: str, buyer_id: int, reason: str) -> OrderReturn:
+        """Buyer requests a return for a shipped or delivered order."""
+        if not reason or not reason.strip():
+            raise ValidationError("Return reason is required")
+
+        with session_scope() as session:
+            order = (
+                session.query(Order).options(db.joinedload(Order.items)).get(order_id)
+            )
+            if not order:
+                raise NotFoundError("Order not found")
+            if order.buyer_id != buyer_id:
+                raise ForbiddenError("You can only request returns for your own orders")
+            if order.status not in RETURNABLE_ORDER_STATUSES:
+                raise ValidationError(
+                    f"Returns are not available for orders in '{order.status.value}' status"
+                )
+
+            existing = (
+                session.query(OrderReturn)
+                .filter(
+                    OrderReturn.order_id == order_id,
+                    OrderReturn.status.in_(
+                        [OrderReturnStatus.REQUESTED, OrderReturnStatus.APPROVED]
+                    ),
+                )
+                .first()
+            )
+            if existing:
+                raise ConflictError("A return request is already open for this order")
+
+            paid_amount = OrderService._get_completed_payment_amount(order)
+            order_return = OrderReturn(
+                order_id=order_id,
+                buyer_id=buyer_id,
+                reason=reason.strip(),
+                status=OrderReturnStatus.REQUESTED,
+                refund_amount=paid_amount if paid_amount > 0 else order.total,
+            )
+            session.add(order_return)
+            session.flush()
+            return order_return
+
+    @staticmethod
+    def approve_return(
+        return_id: str, seller_id: int, seller_notes: Optional[str] = None
+    ):
+        """Seller approves a return and refunds the buyer to wallet."""
+        from app.wallet.services import WalletService
+
+        refund_amount = 0.0
+        buyer_user_id = None
+        order_id = None
+
+        with session_scope() as session:
+            order_return = (
+                session.query(OrderReturn)
+                .options(
+                    db.joinedload(OrderReturn.order).joinedload(Order.items),
+                    db.joinedload(OrderReturn.order).joinedload(Order.buyer),
+                    db.joinedload(OrderReturn.order).joinedload(Order.payments),
+                )
+                .get(return_id)
+            )
+            if not order_return:
+                raise NotFoundError("Return request not found")
+            if order_return.status != OrderReturnStatus.REQUESTED:
+                raise ConflictError("Return request is not pending approval")
+
+            order = order_return.order
+            is_seller = any(item.seller_id == seller_id for item in order.items)
+            if not is_seller:
+                raise ForbiddenError("Only a seller on this order can approve returns")
+
+            refund_amount = (
+                order_return.refund_amount
+                or OrderService._get_completed_payment_amount(order)
+            )
+            if refund_amount <= 0:
+                refund_amount = order.total or 0.0
+
+            buyer_user_id = order.buyer.user_id if order.buyer else None
+            order_id = order.id
+
+            order_return.status = OrderReturnStatus.REFUNDED
+            order_return.seller_notes = seller_notes
+            order.status = OrderStatus.RETURNED
+
+            for item in order.items:
+                if item.status != OrderItem.Status.CANCELLED:
+                    item.status = OrderItem.Status.CANCELLED
+
+            for payment in order.payments or []:
+                if payment.status == PaymentStatus.COMPLETED:
+                    payment.status = PaymentStatus.REFUNDED
+
+            session.flush()
+
+        if refund_amount > 0 and buyer_user_id:
+            from app.wallet.models import WalletReferenceType
+
+            WalletService.credit(
+                buyer_user_id,
+                refund_amount,
+                WalletReferenceType.ORDER_REFUND,
+                return_id,
+                description=f"Return refund for order {order_id}",
+                idempotency_key=f"return-refund:{return_id}",
+            )
+
+        return order_return
+
+    @staticmethod
+    def reject_return(
+        return_id: str, seller_id: int, seller_notes: Optional[str] = None
+    ):
+        """Seller rejects a return request."""
+        with session_scope() as session:
+            order_return = (
+                session.query(OrderReturn)
+                .options(db.joinedload(OrderReturn.order).joinedload(Order.items))
+                .get(return_id)
+            )
+            if not order_return:
+                raise NotFoundError("Return request not found")
+            if order_return.status != OrderReturnStatus.REQUESTED:
+                raise ConflictError("Return request is not pending approval")
+
+            is_seller = any(
+                item.seller_id == seller_id for item in order_return.order.items
+            )
+            if not is_seller:
+                raise ForbiddenError("Only a seller on this order can reject returns")
+
+            order_return.status = OrderReturnStatus.REJECTED
+            order_return.seller_notes = seller_notes
+            session.flush()
+            return order_return
 
     # TODO: Add order history tracking
     # TODO: Add refund processing

--- a/app/orders/services.py
+++ b/app/orders/services.py
@@ -24,6 +24,10 @@ from app.users.models import Buyer
 
 # app imports
 from .models import Order, OrderStatus, OrderItem, ShippingAddress
+from app.orders.shipping import (
+    normalize_shipping_address,
+    shipping_address_to_model_kwargs,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -48,16 +52,7 @@ class OrderService:
                     raise ValidationError("Cannot create order from empty cart")
 
                 # Validate shipping address
-                required_fields = ['recipient_name', 'street_address', 'city', 'state', 'postal_code', 'country']
-                for field in required_fields:
-                    if field not in shipping_address or not shipping_address[field]:
-                        raise ValidationError(f"Missing required shipping address field: {field}")
-
-                # Check for longitude and latitude
-                if 'longitude' not in shipping_address or 'latitude' not in shipping_address:
-                    lat, lon = OrderService._get_geocoordinates(shipping_address)
-                    shipping_address['latitude'] = lat
-                    shipping_address['longitude'] = lon
+                shipping_normalized = normalize_shipping_address(shipping_address)
 
                 # Create single order for buyer
                 # Note: This method is deprecated in favor of CartService.checkout_cart()
@@ -73,7 +68,10 @@ class OrderService:
                 session.flush()
 
                 # Create shipping address
-                shipping_address_obj = ShippingAddress(order_id=order.id, **shipping_address)
+                shipping_address_obj = ShippingAddress(
+                    order_id=order.id,
+                    **shipping_address_to_model_kwargs(shipping_normalized),
+                )
                 session.add(shipping_address_obj)
 
                 # Create order items for each product
@@ -103,49 +101,10 @@ class OrderService:
 
     @staticmethod
     def _get_geocoordinates(address_dict):
-        """
-        Get geocoordinates from address using Nominatim API.
-        Returns (latitude, longitude) as floats.
-        If fails, returns (0.0, 0.0)
-        """
-        try:
-            # Construct address string
-            address_parts = [
-                address_dict.get('street_address', ''),
-                address_dict.get('city', ''),
-                address_dict.get('state', ''),
-                address_dict.get('postal_code', ''),
-                address_dict.get('country', '')
-            ]
-            address_str = ', '.join(part for part in address_parts if part)
+        """Backward-compatible wrapper around shared geocoding helper."""
+        from app.orders.shipping import geocode_address
 
-            if not address_str:
-                return 0.0, 0.0
-
-            # Call Nominatim API
-            url = "https://nominatim.openstreetmap.org/search"
-            params = {
-                'q': address_str,
-                'format': 'json',
-                'limit': 1
-            }
-            headers = {
-                'User-Agent': 'Markt-Commerce-OrderService/1.0'
-            }
-
-            response = requests.get(url, params=params, headers=headers, timeout=10)
-            response.raise_for_status()
-
-            data = response.json()
-            if data:
-                lat = float(data[0]['lat'])
-                lon = float(data[0]['lon'])
-                return lat, lon
-            else:
-                return 0.0, 0.0
-        except Exception as e:
-            logger.warning(f"Failed to get geocoordinates: {e}")
-            return 0.0, 0.0
+        return geocode_address(address_dict)
 
     @staticmethod
     def get_user_orders(user_id):

--- a/app/orders/shipping.py
+++ b/app/orders/shipping.py
@@ -1,0 +1,109 @@
+"""Shared shipping-address validation and normalization for checkout and orders."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional, Tuple
+
+import requests
+
+from app.libs.errors import ValidationError
+
+logger = logging.getLogger(__name__)
+
+REQUIRED_SHIPPING_FIELDS = (
+    "recipient_name",
+    "street_address",
+    "city",
+    "state",
+    "postal_code",
+    "country",
+)
+
+
+def normalize_shipping_address(
+    data: Optional[Dict[str, Any]],
+    *,
+    saved_address: Optional[Dict[str, Any]] = None,
+    use_saved_address: bool = False,
+) -> Dict[str, Any]:
+    """Validate and normalize a shipping address payload.
+
+    Accepts ``street`` as an alias for ``street_address``.
+    When ``use_saved_address`` is true, missing fields are filled from ``saved_address``.
+    """
+    if use_saved_address and saved_address:
+        base = dict(saved_address)
+        if data:
+            base.update({k: v for k, v in data.items() if v is not None})
+        data = base
+
+    if not data:
+        raise ValidationError("shipping_address is required")
+
+    normalized = {
+        "recipient_name": data.get("recipient_name"),
+        "street_address": data.get("street_address") or data.get("street"),
+        "city": data.get("city"),
+        "state": data.get("state"),
+        "postal_code": data.get("postal_code") or data.get("zip"),
+        "country": data.get("country"),
+        "latitude": data.get("latitude"),
+        "longitude": data.get("longitude"),
+    }
+
+    missing = [field for field in REQUIRED_SHIPPING_FIELDS if not normalized.get(field)]
+    if missing:
+        raise ValidationError(
+            f"Missing required shipping address field(s): {', '.join(missing)}"
+        )
+
+    if normalized["latitude"] is None or normalized["longitude"] is None:
+        lat, lon = geocode_address(normalized)
+        normalized["latitude"] = lat
+        normalized["longitude"] = lon
+
+    return normalized
+
+
+def geocode_address(address_dict: Dict[str, Any]) -> Tuple[float, float]:
+    """Resolve coordinates from address using Nominatim. Returns (0.0, 0.0) on failure."""
+    try:
+        address_parts = [
+            address_dict.get("street_address", ""),
+            address_dict.get("city", ""),
+            address_dict.get("state", ""),
+            address_dict.get("postal_code", ""),
+            address_dict.get("country", ""),
+        ]
+        address_str = ", ".join(part for part in address_parts if part)
+        if not address_str:
+            return 0.0, 0.0
+
+        response = requests.get(
+            "https://nominatim.openstreetmap.org/search",
+            params={"q": address_str, "format": "json", "limit": 1},
+            headers={"User-Agent": "Markt-Commerce/1.0"},
+            timeout=10,
+        )
+        response.raise_for_status()
+        results = response.json()
+        if results:
+            return float(results[0]["lat"]), float(results[0]["lon"])
+    except Exception as exc:
+        logger.warning("Failed to geocode address: %s", exc)
+    return 0.0, 0.0
+
+
+def shipping_address_to_model_kwargs(normalized: Dict[str, Any]) -> Dict[str, Any]:
+    """Map normalized dict to ``ShippingAddress`` column kwargs."""
+    return {
+        "recipient_name": normalized["recipient_name"],
+        "street_address": normalized["street_address"],
+        "city": normalized["city"],
+        "state": normalized["state"],
+        "postal_code": normalized["postal_code"],
+        "country": normalized["country"],
+        "latitude": normalized["latitude"],
+        "longitude": normalized["longitude"],
+    }

--- a/app/orders/tasks.py
+++ b/app/orders/tasks.py
@@ -1,0 +1,42 @@
+"""Celery tasks for order lifecycle maintenance."""
+
+import logging
+from datetime import datetime, timedelta
+
+from main.workers import celery_app
+from app.libs.session import session_scope
+from app.orders.models import Order, OrderStatus
+
+logger = logging.getLogger(__name__)
+
+
+@celery_app.task(name="app.orders.tasks.expire_unpaid_orders", queue="default")
+def expire_unpaid_orders():
+    """Cancel orders stuck in pending_payment beyond the configured TTL."""
+    from main.config import settings
+
+    cutoff = datetime.utcnow() - timedelta(hours=settings.UNPAID_ORDER_EXPIRY_HOURS)
+    expired_count = 0
+
+    with session_scope() as session:
+        stale_orders = (
+            session.query(Order)
+            .filter(
+                Order.status.in_([OrderStatus.PENDING_PAYMENT, OrderStatus.PENDING]),
+                Order.created_at < cutoff,
+            )
+            .all()
+        )
+
+        for order in stale_orders:
+            order.status = OrderStatus.CANCELLED
+            order.cancelled_at = datetime.utcnow()
+            order.cancel_reason = "Automatically cancelled — payment not received"
+            expired_count += 1
+
+    logger.info(
+        "Expired %s unpaid orders older than %sh",
+        expired_count,
+        settings.UNPAID_ORDER_EXPIRY_HOURS,
+    )
+    return {"expired": expired_count}

--- a/app/payments/routes.py
+++ b/app/payments/routes.py
@@ -175,42 +175,46 @@ class PaymentInitialize(MethodView):
 @bp.route("/callback/<payment_id>")
 class PaymentCallback(MethodView):
     def get(self, payment_id):
-        """Handle payment callback from Paystack and redirect to frontend"""
+        """Handle payment callback from Paystack and redirect to the mobile app or web app"""
         from flask import redirect
+        from urllib.parse import urlencode
         from main.config import settings
+
+        # The platform is set on the callback_url when the payment was
+        # initialized (see PaymentService._initialize_paystack_transaction)
+        # and echoed back by Paystack's redirect.
+        platform = request.args.get("platform", "web")
+
+        def client_redirect(status: str, **params):
+            query_params = {k: v for k, v in params.items() if v is not None}
+            query = urlencode(query_params)
+            if platform == "mobile":
+                url = f"{settings.MOBILE_APP_SCHEME}payment/{status}"
+            else:
+                url = f"{settings.WEB_APP_BASE_URL}/payment-{status}"
+            return redirect(f"{url}?{query}" if query else url)
 
         try:
             # Get reference from query params
             reference = request.args.get("reference")
             if not reference:
-                # Redirect to frontend error page
-                frontend_url = settings.FRONTEND_BASE_URL or "http://localhost:3000"
-                return redirect(
-                    f"{frontend_url}/payment/failed?error=missing_reference"
-                )
+                return client_redirect("failed", error="missing_reference")
 
             # Verify payment
             verification_result = PaymentService.verify_payment(payment_id)
 
-            # Get frontend URL from config
-            frontend_url = settings.FRONTEND_BASE_URL or "http://localhost:3000"
-
             if verification_result["verified"]:
-                # Redirect to frontend success page
-                return redirect(
-                    f"{frontend_url}/payment/success?payment_id={payment_id}&reference={reference}"
+                return client_redirect(
+                    "success", payment_id=payment_id, reference=reference
                 )
             else:
-                # Redirect to frontend failure page
-                return redirect(
-                    f"{frontend_url}/payment/failed?payment_id={payment_id}&reference={reference}"
+                return client_redirect(
+                    "failed", payment_id=payment_id, reference=reference
                 )
 
         except Exception as e:
             current_app.logger.error(f"Payment callback error: {str(e)}")
-            # Redirect to frontend error page
-            frontend_url = settings.FRONTEND_BASE_URL or "http://localhost:3000"
-            return redirect(f"{frontend_url}/payment/failed?error=server_error")
+            return client_redirect("failed", error="server_error")
 
 
 # Admin routes for payment management

--- a/app/payments/routes.py
+++ b/app/payments/routes.py
@@ -100,12 +100,15 @@ class PaystackWebhook(MethodView):
                 abort(400, message="Missing webhook signature")
 
             # Get webhook payload
+            raw_body = request.get_data()
             payload = request.get_json()
             if not payload:
                 abort(400, message="Invalid webhook payload")
 
             # Process webhook
-            success = PaymentService.handle_webhook(payload, signature)
+            success = PaymentService.handle_webhook(
+                payload, signature, raw_body=raw_body
+            )
 
             if success:
                 return jsonify({"status": "success"}), 200

--- a/app/payments/schemas.py
+++ b/app/payments/schemas.py
@@ -25,7 +25,16 @@ class PaymentCreateSchema(Schema):
     """Payment creation schema"""
 
     order_id = fields.Str(required=True)
-    amount = fields.Float(required=True, validate=validate.Range(min=0))
+    amount = fields.Float(
+        validate=validate.Range(min=0),
+        allow_none=True,
+        metadata={
+            "description": (
+                "Optional. When provided, must match order.total exactly. "
+                "Server always charges order.total."
+            )
+        },
+    )
     currency = fields.Str(validate=validate.Length(equal=3), missing="NGN")
     method = fields.Str(missing="card")  # PaymentMethod.CARD.value
     metadata = fields.Dict(missing={})

--- a/app/payments/services.py
+++ b/app/payments/services.py
@@ -23,7 +23,7 @@ from app.libs.errors import (
 
 # app imports
 from .models import Payment, Transaction, PaymentStatus, PaymentMethod
-from app.orders.models import Order, OrderStatus
+from app.orders.models import Order, OrderStatus, OrderItem
 from app.users.models import User, Seller
 from app.notifications.services import NotificationService
 from app.notifications.models import NotificationType
@@ -49,6 +49,131 @@ class PaymentService:
         cls.PAYSTACK_SECRET_KEY = secret_key
         cls.PAYSTACK_PUBLIC_KEY = public_key
         logger.info("Paystack payment service initialized")
+
+    @staticmethod
+    def _resolve_order_payment_amount(
+        order: Order, client_amount: Optional[float]
+    ) -> float:
+        """Derive the payable amount from the order; optionally validate client input."""
+        expected = order.total if order.total is not None else order.subtotal
+        if expected is None:
+            raise ValidationError("Order total is not set")
+        if client_amount is not None and abs(client_amount - expected) > 0.01:
+            raise ValidationError(
+                f"Payment amount {client_amount} does not match order total {expected}"
+            )
+        return expected
+
+    @staticmethod
+    def complete_payment(
+        *,
+        payment_id: Optional[str] = None,
+        reference: Optional[str] = None,
+        gateway_response: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """Idempotently mark a payment completed and advance the order lifecycle."""
+        if not payment_id and not reference:
+            return False
+
+        with session_scope() as session:
+            query = session.query(Payment).options(
+                joinedload(Payment.order).joinedload(Order.items),
+                joinedload(Payment.order).joinedload(Order.buyer),
+            )
+            if payment_id:
+                payment = query.get(payment_id)
+            else:
+                payment = query.filter_by(transaction_id=reference).first()
+
+            if not payment:
+                logger.warning(
+                    "complete_payment: payment not found (id=%s, ref=%s)",
+                    payment_id,
+                    reference,
+                )
+                return False
+
+            already_completed = payment.status == PaymentStatus.COMPLETED
+
+            if not already_completed:
+                payment.status = PaymentStatus.COMPLETED
+                payment.paid_at = datetime.utcnow()
+                if gateway_response is not None:
+                    payment.gateway_response = gateway_response
+
+            order = payment.order
+            if order and order.status in (
+                OrderStatus.PENDING,
+                OrderStatus.PENDING_PAYMENT,
+            ):
+                order.status = OrderStatus.READY_FOR_DELIVERY
+                if not order.order_number:
+                    order.order_number = order.generate_order_number()
+
+                for item in order.items:
+                    if item.status == OrderItem.Status.PENDING:
+                        item.status = OrderItem.Status.PROCESSING
+
+                if not already_completed:
+                    from app.products.services import ProductService
+
+                    ProductService.reduce_inventory_for_order(order.items)
+
+                    existing_txn = (
+                        session.query(Transaction)
+                        .filter_by(reference=f"PAY_{payment.id}")
+                        .first()
+                    )
+                    if not existing_txn:
+                        transaction = Transaction(
+                            user_id=order.buyer.user_id,
+                            seller_id=order.items[0].seller_id if order.items else None,
+                            amount=payment.amount,
+                            type="debit",
+                            reference=f"PAY_{payment.id}",
+                            status="completed",
+                            payment_metadata=gateway_response or {},
+                        )
+                        session.add(transaction)
+
+            session.flush()
+
+            if not already_completed:
+                PaymentService._send_payment_notifications(
+                    payment, PaymentStatus.COMPLETED
+                )
+                PaymentService._emit_payment_confirmed(payment)
+
+            PaymentService._invalidate_payment_cache(payment.id)
+            return True
+
+    @staticmethod
+    def _emit_payment_confirmed(payment: Payment):
+        try:
+            from app.realtime.event_manager import EventManager
+
+            EventManager.emit_to_order(
+                payment.order_id,
+                "payment_confirmed",
+                {
+                    "payment_id": payment.id,
+                    "order_id": payment.order_id,
+                    "user_id": payment.order.buyer.user_id
+                    if payment.order and payment.order.buyer
+                    else None,
+                    "amount": payment.amount,
+                    "status": payment.status.value,
+                    "transaction_id": payment.transaction_id,
+                    "metadata": {
+                        "method": payment.method.value if payment.method else None,
+                        "order_number": payment.order.order_number
+                        if payment.order
+                        else None,
+                    },
+                },
+            )
+        except Exception as e:
+            logger.warning(f"Failed to queue payment_confirmed event: {e}")
 
     @staticmethod
     def create_payment(
@@ -78,6 +203,10 @@ class PaymentService:
             if not order:
                 raise NotFoundError("Order not found")
 
+            resolved_amount = PaymentService._resolve_order_payment_amount(
+                order, amount
+            )
+
             # Accept both PENDING and PENDING_PAYMENT for backward compatibility
             if order.status not in (OrderStatus.PENDING, OrderStatus.PENDING_PAYMENT):
                 raise ValidationError(
@@ -94,7 +223,7 @@ class PaymentService:
             # Create payment record
             payment = Payment(
                 order_id=order_id,
-                amount=amount,
+                amount=resolved_amount,
                 currency=currency,
                 method=method,
                 status=PaymentStatus.PENDING,
@@ -117,6 +246,10 @@ class PaymentService:
     @staticmethod
     def process_payment(payment_id: str, payment_data: Dict[str, Any]) -> Payment:
         """Process payment with Paystack"""
+        resolved_id = payment_id
+        gateway_response: Dict[str, Any] = {}
+        result_status: Optional[PaymentStatus] = None
+
         with session_scope() as session:
             payment = session.query(Payment).get(payment_id)
             if not payment:
@@ -126,7 +259,6 @@ class PaymentService:
                 raise ValidationError("Payment is not in pending status")
 
             try:
-                # Process with Paystack
                 if payment.method == PaymentMethod.CARD:
                     result = PaymentService._process_paystack_payment(
                         payment, payment_data
@@ -140,127 +272,90 @@ class PaymentService:
                         f"Unsupported payment method: {payment.method}"
                     )
 
-                # Update payment status
                 payment.status = result["status"]
-                payment.transaction_id = result.get("transaction_id")
+                if result.get("transaction_id"):
+                    payment.transaction_id = result["transaction_id"]
                 payment.gateway_response = result.get("gateway_response", {})
+                result_status = result["status"]
+                gateway_response = payment.gateway_response
+                resolved_id = payment.id
 
                 if result["status"] == PaymentStatus.COMPLETED:
                     payment.paid_at = datetime.utcnow()
-
-                # Update order status to processing after payment succeeds
-                order = session.query(Order).get(payment.order_id)
-                if order:
-                    # Move from PENDING_PAYMENT (or PENDING for backward compat) to PROCESSING
-                    if order.status in (
-                        OrderStatus.PENDING,
-                        OrderStatus.PENDING_PAYMENT,
-                    ):
-                        order.status = OrderStatus.PROCESSING
-
-                        # Reduce inventory for all order items
-                        from app.products.services import ProductService
-
-                        ProductService.reduce_inventory_for_order(order.items)
-
-                        # Create transaction record
-                        transaction = Transaction(
-                            user_id=order.buyer.user_id,
-                            seller_id=order.items[0].product.seller_id
-                            if order.items
-                            else None,
-                            amount=payment.amount,
-                            type="debit",
-                            reference=f"PAY_{payment.id}",
-                            status="completed",
-                            payment_metadata=result.get("gateway_response", {}),
-                        )
-                        session.add(transaction)
+                elif result["status"] == PaymentStatus.FAILED:
+                    PaymentService._send_payment_notifications(
+                        payment, PaymentStatus.FAILED
+                    )
 
                 session.flush()
-
-                # Send notifications
-                PaymentService._send_payment_notifications(payment, result["status"])
-
-                # Queue async real-time event (non-blocking)
-                try:
-                    from app.realtime.event_manager import EventManager
-
-                    EventManager.emit_to_order(
-                        payment.order_id,
-                        "payment_confirmed",
-                        {
-                            "payment_id": payment.id,
-                            "order_id": payment.order_id,
-                            "user_id": payment.order.buyer.user_id
-                            if payment.order and payment.order.buyer
-                            else None,
-                            "amount": payment.amount,
-                            "status": payment.status.value,
-                            "transaction_id": payment.transaction_id,
-                            "metadata": {
-                                "method": payment.method.value
-                                if payment.method
-                                else None,
-                                "order_number": payment.order.order_number
-                                if payment.order
-                                else None,
-                            },
-                        },
-                    )
-                except Exception as e:
-                    logger.warning(f"Failed to queue payment_confirmed event: {e}")
-
-                return payment
 
             except Exception as e:
                 logger.error(f"Payment processing failed: {str(e)}")
                 payment.status = PaymentStatus.FAILED
                 payment.gateway_response = {"error": str(e)}
                 session.flush()
-
-                # Send failure notification
                 PaymentService._send_payment_notifications(
                     payment, PaymentStatus.FAILED
                 )
                 raise APIError("Payment processing failed", 500)
 
+        if result_status == PaymentStatus.COMPLETED:
+            PaymentService.complete_payment(
+                payment_id=resolved_id,
+                gateway_response=gateway_response,
+            )
+
+        return PaymentService.get_payment(resolved_id)
+
     @staticmethod
     def verify_payment(payment_id: str) -> Dict[str, Any]:
-        """Verify payment status with Paystack"""
+        """Verify payment status with Paystack and persist success when confirmed."""
         with session_scope() as session:
             payment = session.query(Payment).get(payment_id)
             if not payment:
                 raise NotFoundError("Payment not found")
 
+            if payment.status == PaymentStatus.COMPLETED:
+                return {
+                    "verified": True,
+                    "amount": payment.amount,
+                    "gateway_response": payment.gateway_response,
+                    "already_completed": True,
+                }
+
             if not payment.transaction_id:
                 raise ValidationError("No transaction ID to verify")
 
-            try:
-                # Verify with Paystack
-                response = requests.get(
-                    f"{PaymentService.PAYSTACK_BASE_URL}/transaction/verify/{payment.transaction_id}",
-                    headers={
-                        "Authorization": f"Bearer {PaymentService.PAYSTACK_SECRET_KEY}"
-                    },
-                )
+            transaction_id = payment.transaction_id
 
-                if response.status_code == 200:
-                    data = response.json()
-                    if data["status"] and data["data"]["status"] == "success":
-                        return {
-                            "verified": True,
-                            "amount": data["data"]["amount"] / 100,  # Convert from kobo
-                            "gateway_response": data,
-                        }
-                    else:
-                        return {"verified": False, "gateway_response": data}
-                else:
-                    raise APIError("Failed to verify payment with gateway", 500)
+        try:
+            response = requests.get(
+                f"{PaymentService.PAYSTACK_BASE_URL}/transaction/verify/{transaction_id}",
+                headers={
+                    "Authorization": f"Bearer {PaymentService.PAYSTACK_SECRET_KEY}"
+                },
+            )
 
-            except Exception as e:
-                logger.error(f"Payment verification failed: {str(e)}")
-                raise APIError("Payment verification failed", 500)
+            if response.status_code == 200:
+                data = response.json()
+                if data["status"] and data["data"]["status"] == "success":
+                    PaymentService.complete_payment(
+                        payment_id=payment_id,
+                        gateway_response=data,
+                    )
+                    return {
+                        "verified": True,
+                        "amount": data["data"]["amount"] / 100,
+                        "gateway_response": data,
+                    }
+                return {"verified": False, "gateway_response": data}
+            raise APIError("Failed to verify payment with gateway", 500)
+
+        except APIError:
+            raise
+        except Exception as e:
+            logger.error(f"Payment verification failed: {str(e)}")
+            raise APIError("Payment verification failed", 500)
 
     @staticmethod
     def get_payment(payment_id: str) -> Payment:
@@ -558,79 +653,13 @@ class PaymentService:
     @staticmethod
     def _handle_successful_charge(data: Dict[str, Any]) -> bool:
         """Handle successful charge webhook"""
-        try:
-            reference = data.get("reference")
-            if not reference:
-                return False
-
-            with session_scope() as session:
-                payment = (
-                    session.query(Payment).filter_by(transaction_id=reference).first()
-                )
-                if not payment:
-                    logger.warning(f"Payment not found for reference: {reference}")
-                    return False
-
-                payment.status = PaymentStatus.COMPLETED
-                payment.paid_at = datetime.utcnow()
-                payment.gateway_response = data
-
-                # Update order status to processing after payment succeeds
-                order = session.query(Order).get(payment.order_id)
-                if order:
-                    # Move from PENDING_PAYMENT (or PENDING for backward compat) to PROCESSING
-                    if order.status in (
-                        OrderStatus.PENDING,
-                        OrderStatus.PENDING_PAYMENT,
-                    ):
-                        order.status = OrderStatus.PROCESSING
-
-                    # Reduce inventory for all order items
-                    from app.products.services import ProductService
-
-                    ProductService.reduce_inventory_for_order(order.items)
-
-                session.flush()
-
-                # Send notifications
-                PaymentService._send_payment_notifications(
-                    payment, PaymentStatus.COMPLETED
-                )
-
-                # Queue async real-time event (non-blocking)
-                try:
-                    from app.realtime.event_manager import EventManager
-
-                    EventManager.emit_to_order(
-                        payment.order_id,
-                        "payment_confirmed",
-                        {
-                            "payment_id": payment.id,
-                            "order_id": payment.order_id,
-                            "user_id": payment.order.buyer.user_id
-                            if payment.order and payment.order.buyer
-                            else None,
-                            "amount": payment.amount,
-                            "status": payment.status.value,
-                            "transaction_id": payment.transaction_id,
-                            "metadata": {
-                                "method": payment.method.value
-                                if payment.method
-                                else None,
-                                "order_number": payment.order.order_number
-                                if payment.order
-                                else None,
-                            },
-                        },
-                    )
-                except Exception as e:
-                    logger.warning(f"Failed to queue payment_confirmed event: {e}")
-
-                return True
-
-        except Exception as e:
-            logger.error(f"Failed to handle successful charge: {str(e)}")
+        reference = data.get("reference")
+        if not reference:
             return False
+        return PaymentService.complete_payment(
+            reference=reference,
+            gateway_response=data,
+        )
 
     @staticmethod
     def _handle_failed_charge(data: Dict[str, Any]) -> bool:

--- a/app/payments/services.py
+++ b/app/payments/services.py
@@ -199,7 +199,7 @@ class PaymentService:
                     return existing_payment
 
             # Validate order
-            order = session.query(Order).get(order_id)
+            order = session.query(Order).options(joinedload(Order.buyer)).get(order_id)
             if not order:
                 raise NotFoundError("Order not found")
 
@@ -234,14 +234,37 @@ class PaymentService:
             session.add(payment)
             session.flush()
 
-            # Initialize with Paystack if card payment
-            if method == PaymentMethod.CARD:
+            wallet_payment_id = None
+
+            if method == PaymentMethod.WALLET:
+                if not order.buyer or not order.buyer.user_id:
+                    raise ValidationError("Buyer account required for wallet payment")
+                from app.wallet.services import WalletService
+
+                payment.transaction_id = f"WALLET_{payment.id}"
+                WalletService.pay_for_order(
+                    order.buyer.user_id,
+                    order_id,
+                    payment.id,
+                    resolved_amount,
+                    currency=currency,
+                )
+                payment.status = PaymentStatus.COMPLETED
+                payment.paid_at = datetime.utcnow()
+                wallet_payment_id = payment.id
+            elif method == PaymentMethod.CARD:
                 PaymentService._initialize_paystack_transaction(payment, metadata)
 
-            # Cache payment
             PaymentService._cache_payment(payment)
 
-            return payment
+            if wallet_payment_id:
+                session.flush()
+
+        if wallet_payment_id:
+            PaymentService.complete_payment(payment_id=wallet_payment_id)
+            return PaymentService.get_payment(wallet_payment_id)
+
+        return payment
 
     @staticmethod
     def process_payment(payment_id: str, payment_data: Dict[str, Any]) -> Payment:
@@ -415,11 +438,14 @@ class PaymentService:
             }
 
     @staticmethod
-    def handle_webhook(payload: Dict[str, Any], signature: str) -> bool:
+    def handle_webhook(
+        payload: Dict[str, Any],
+        signature: str,
+        raw_body: Optional[bytes] = None,
+    ) -> bool:
         """Handle Paystack webhook"""
         try:
-            # Verify webhook signature
-            if not PaymentService._verify_webhook_signature(payload, signature):
+            if not PaymentService._verify_webhook_signature(signature, raw_body):
                 logger.warning("Invalid webhook signature")
                 return False
 
@@ -430,6 +456,8 @@ class PaymentService:
                 return PaymentService._handle_successful_charge(data)
             elif event == "transfer.success":
                 return PaymentService._handle_successful_transfer(data)
+            elif event == "transfer.failed":
+                return PaymentService._handle_failed_transfer(data)
             elif event == "charge.failed":
                 return PaymentService._handle_failed_charge(data)
             else:
@@ -441,6 +469,27 @@ class PaymentService:
             return False
 
     # ==================== PRIVATE METHODS ====================
+
+    @staticmethod
+    def _resolve_subaccount_split(order: Order) -> Optional[Dict[str, str]]:
+        """Return Paystack subaccount code when order has a single registered seller."""
+        seller_ids = {item.seller_id for item in order.items if item.seller_id}
+        if len(seller_ids) != 1:
+            return None
+
+        seller_id = next(iter(seller_ids))
+        seller = (
+            order.items[0].seller
+            if order.items and order.items[0].seller_id == seller_id
+            else None
+        )
+        if not seller:
+            with session_scope() as session:
+                seller = session.query(Seller).get(seller_id)
+        if not seller or not seller.paystack_subaccount_code:
+            return None
+
+        return {"subaccount_code": seller.paystack_subaccount_code}
 
     @staticmethod
     def _initialize_paystack_transaction(
@@ -487,6 +536,11 @@ class PaymentService:
                     **(metadata or {}),
                 },
             }
+
+            split = PaymentService._resolve_subaccount_split(order)
+            if split:
+                payload["subaccount"] = split["subaccount_code"]
+                order.paystack_split_used = True
 
             response = requests.post(
                 f"{PaymentService.PAYSTACK_BASE_URL}/transaction/initialize",
@@ -636,16 +690,16 @@ class PaymentService:
             raise APIError("Bank transfer processing failed", 500)
 
     @staticmethod
-    def _verify_webhook_signature(payload: Dict[str, Any], signature: str) -> bool:
-        """Verify Paystack webhook signature"""
+    def _verify_webhook_signature(signature: str, raw_body: Optional[bytes]) -> bool:
+        """Verify Paystack webhook signature against the raw request body."""
+        if not signature or not raw_body:
+            return False
         try:
-            # Create HMAC SHA512 hash
             computed_signature = hmac.new(
                 PaymentService.PAYSTACK_SECRET_KEY.encode("utf-8"),
-                str(payload).encode("utf-8"),
+                raw_body,
                 hashlib.sha512,
             ).hexdigest()
-
             return hmac.compare_digest(computed_signature, signature)
         except Exception:
             return False
@@ -656,6 +710,13 @@ class PaymentService:
         reference = data.get("reference")
         if not reference:
             return False
+
+        metadata = data.get("metadata") or {}
+        if reference.startswith("TOP_") or metadata.get("type") == "wallet_topup":
+            from app.wallet.services import WalletService
+
+            return WalletService.complete_topup(reference, data)
+
         return PaymentService.complete_payment(
             reference=reference,
             gateway_response=data,
@@ -696,9 +757,24 @@ class PaymentService:
 
     @staticmethod
     def _handle_successful_transfer(data: Dict[str, Any]) -> bool:
-        """Handle successful transfer webhook (for payouts)"""
-        # Implementation for seller payouts
-        return True
+        """Handle successful transfer webhook (wallet withdrawals)."""
+        from app.wallet.services import WalletService
+
+        reference = data.get("reference") or data.get("transfer_code")
+        if not reference:
+            return False
+        return WalletService.complete_withdrawal_transfer(reference)
+
+    @staticmethod
+    def _handle_failed_transfer(data: Dict[str, Any]) -> bool:
+        """Handle failed transfer webhook and refund wallet."""
+        from app.wallet.services import WalletService
+
+        reference = data.get("reference") or data.get("transfer_code")
+        if not reference:
+            return False
+        reason = data.get("reason") or "Paystack transfer failed"
+        return WalletService.fail_withdrawal_transfer(reference, reason)
 
     @staticmethod
     def _send_payment_notifications(payment: Payment, status: PaymentStatus):

--- a/app/payments/services.py
+++ b/app/payments/services.py
@@ -370,7 +370,14 @@ class PaymentService:
                 except:
                     base_url = "http://localhost:8000"  # Final fallback
 
-            callback_url = f"{base_url}/api/v1/payments/callback/{payment.id}"
+            # Carry the originating platform through Paystack's redirect so the
+            # final callback knows whether to send the user back to the mobile
+            # app (deep link) or the web app.
+            platform = (metadata or {}).get("platform", "web")
+            callback_url = (
+                f"{base_url}/api/v1/payments/callback/{payment.id}"
+                f"?platform={platform}"
+            )
 
             payload = {
                 "amount": int(payment.amount * 100),  # Convert to kobo

--- a/app/products/services.py
+++ b/app/products/services.py
@@ -946,6 +946,44 @@ class ProductService:
             raise APIError(f"Inventory reduction failed: {str(e)}", 500)
 
     @staticmethod
+    def restore_inventory_for_order(order_items: List[OrderItem]) -> bool:
+        """Restore inventory when a paid order is cancelled."""
+        try:
+            with session_scope() as session:
+                for item in order_items:
+                    if item.variant_id:
+                        inventory = (
+                            session.query(ProductInventory)
+                            .filter_by(
+                                product_id=item.product_id, variant_id=item.variant_id
+                            )
+                            .first()
+                        )
+                        if inventory:
+                            inventory.quantity += item.quantity
+                        else:
+                            inventory = ProductInventory(
+                                product_id=item.product_id,
+                                variant_id=item.variant_id,
+                                quantity=item.quantity,
+                            )
+                            session.add(inventory)
+                    else:
+                        product = session.query(Product).get(item.product_id)
+                        if not product:
+                            continue
+                        product.stock += item.quantity
+                        if product.status == Product.Status.OUT_OF_STOCK:
+                            product.status = Product.Status.ACTIVE
+
+                session.flush()
+                logger.info("Successfully restored inventory for cancelled order")
+                return True
+        except Exception as e:
+            logger.error(f"Failed to restore inventory: {str(e)}")
+            raise APIError(f"Inventory restoration failed: {str(e)}", 500)
+
+    @staticmethod
     def check_inventory_availability(order_items: List[OrderItem]) -> bool:
         """Check if all order items have sufficient inventory"""
         try:

--- a/app/users/models.py
+++ b/app/users/models.py
@@ -52,6 +52,12 @@ class User(BaseModel, UserMixin, UniqueIdMixin):
         "Notification", back_populates="user", lazy="dynamic"
     )
     transactions = db.relationship("Transaction", back_populates="user", lazy="dynamic")
+    wallet_accounts = db.relationship(
+        "WalletAccount", back_populates="user", lazy="dynamic"
+    )
+    withdrawal_requests = db.relationship(
+        "WithdrawalRequest", back_populates="user", lazy="dynamic"
+    )
     posts = db.relationship("Post", back_populates="user", lazy="dynamic")
     post_likes = db.relationship("PostLike", back_populates="user", lazy="dynamic")
     post_comments = db.relationship(

--- a/app/users/models.py
+++ b/app/users/models.py
@@ -58,6 +58,9 @@ class User(BaseModel, UserMixin, UniqueIdMixin):
     withdrawal_requests = db.relationship(
         "WithdrawalRequest", back_populates="user", lazy="dynamic"
     )
+    wallet_topups = db.relationship(
+        "WalletTopUp", back_populates="user", lazy="dynamic"
+    )
     posts = db.relationship("Post", back_populates="user", lazy="dynamic")
     post_likes = db.relationship("PostLike", back_populates="user", lazy="dynamic")
     post_comments = db.relationship(
@@ -219,6 +222,10 @@ class Seller(BaseModel):
     )
     is_active = db.Column(db.Boolean, default=True)
     deactivated_at = db.Column(db.DateTime)
+    paystack_subaccount_code = db.Column(db.String(50), nullable=True)
+    payout_bank_code = db.Column(db.String(10), nullable=True)
+    payout_account_number = db.Column(db.String(20), nullable=True)
+    payout_account_name = db.Column(db.String(100), nullable=True)
 
     # Relationships
     user = db.relationship("User", back_populates="seller_account")

--- a/app/wallet/models.py
+++ b/app/wallet/models.py
@@ -1,0 +1,80 @@
+from enum import Enum
+
+from external.database import db
+from app.libs.models import BaseModel
+from app.libs.helpers import UniqueIdMixin
+
+
+class WalletEntryType(Enum):
+    CREDIT = "credit"
+    DEBIT = "debit"
+
+
+class WalletReferenceType(Enum):
+    ORDER_SETTLEMENT = "order_settlement"
+    ORDER_REFUND = "order_refund"
+    WITHDRAWAL = "withdrawal"
+    ADJUSTMENT = "adjustment"
+
+
+class WithdrawalStatus(Enum):
+    PENDING = "pending"
+    PROCESSING = "processing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class WalletAccount(BaseModel):
+    __tablename__ = "wallet_accounts"
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.String(12), db.ForeignKey("users.id"), nullable=False)
+    currency = db.Column(db.String(3), default="NGN", nullable=False)
+    available_balance = db.Column(db.Float, default=0.0, nullable=False)
+
+    user = db.relationship("User", back_populates="wallet_accounts")
+    entries = db.relationship(
+        "WalletEntry", back_populates="wallet_account", lazy="dynamic"
+    )
+
+    __table_args__ = (
+        db.UniqueConstraint("user_id", "currency", name="uq_wallet_user_currency"),
+    )
+
+
+class WalletEntry(BaseModel):
+    __tablename__ = "wallet_entries"
+
+    id = db.Column(db.Integer, primary_key=True)
+    wallet_account_id = db.Column(
+        db.Integer, db.ForeignKey("wallet_accounts.id"), nullable=False
+    )
+    entry_type = db.Column(db.Enum(WalletEntryType), nullable=False)
+    amount = db.Column(db.Float, nullable=False)
+    balance_after = db.Column(db.Float, nullable=False)
+    reference_type = db.Column(db.Enum(WalletReferenceType), nullable=False)
+    reference_id = db.Column(db.String(50), nullable=False)
+    description = db.Column(db.String(255))
+    idempotency_key = db.Column(db.String(100), unique=True, nullable=True)
+
+    wallet_account = db.relationship("WalletAccount", back_populates="entries")
+
+
+class WithdrawalRequest(BaseModel, UniqueIdMixin):
+    __tablename__ = "withdrawal_requests"
+    id_prefix = "WDR_"
+
+    id = db.Column(db.String(12), primary_key=True, default=None)
+    user_id = db.Column(db.String(12), db.ForeignKey("users.id"), nullable=False)
+    amount = db.Column(db.Float, nullable=False)
+    currency = db.Column(db.String(3), default="NGN", nullable=False)
+    bank_code = db.Column(db.String(10), nullable=False)
+    account_number = db.Column(db.String(20), nullable=False)
+    account_name = db.Column(db.String(100), nullable=False)
+    status = db.Column(
+        db.Enum(WithdrawalStatus), default=WithdrawalStatus.PENDING, nullable=False
+    )
+    paystack_transfer_ref = db.Column(db.String(100), nullable=True)
+    failure_reason = db.Column(db.String(255), nullable=True)
+
+    user = db.relationship("User", back_populates="withdrawal_requests")

--- a/app/wallet/models.py
+++ b/app/wallet/models.py
@@ -13,8 +13,16 @@ class WalletEntryType(Enum):
 class WalletReferenceType(Enum):
     ORDER_SETTLEMENT = "order_settlement"
     ORDER_REFUND = "order_refund"
+    ORDER_PAYMENT = "order_payment"
+    WALLET_TOPUP = "wallet_topup"
     WITHDRAWAL = "withdrawal"
     ADJUSTMENT = "adjustment"
+
+
+class TopUpStatus(Enum):
+    PENDING = "pending"
+    COMPLETED = "completed"
+    FAILED = "failed"
 
 
 class WithdrawalStatus(Enum):
@@ -78,3 +86,19 @@ class WithdrawalRequest(BaseModel, UniqueIdMixin):
     failure_reason = db.Column(db.String(255), nullable=True)
 
     user = db.relationship("User", back_populates="withdrawal_requests")
+
+
+class WalletTopUp(BaseModel, UniqueIdMixin):
+    __tablename__ = "wallet_topups"
+    id_prefix = "TOP_"
+
+    id = db.Column(db.String(12), primary_key=True, default=None)
+    user_id = db.Column(db.String(12), db.ForeignKey("users.id"), nullable=False)
+    amount = db.Column(db.Float, nullable=False)
+    currency = db.Column(db.String(3), default="NGN", nullable=False)
+    status = db.Column(
+        db.Enum(TopUpStatus), default=TopUpStatus.PENDING, nullable=False
+    )
+    paystack_reference = db.Column(db.String(100), unique=True, nullable=True)
+
+    user = db.relationship("User", back_populates="wallet_topups")

--- a/app/wallet/paystack_subaccounts.py
+++ b/app/wallet/paystack_subaccounts.py
@@ -1,0 +1,51 @@
+"""Paystack subaccount helpers for seller split payments."""
+
+import logging
+from typing import Any, Dict
+
+import requests
+
+from app.libs.errors import APIError
+
+logger = logging.getLogger(__name__)
+
+
+class PaystackSubaccountClient:
+    BASE_URL = "https://api.paystack.co"
+
+    @classmethod
+    def _headers(cls) -> Dict[str, str]:
+        from app.payments.services import PaymentService
+
+        if not PaymentService.PAYSTACK_SECRET_KEY:
+            raise APIError("Paystack is not configured", 503)
+        return {"Authorization": f"Bearer {PaymentService.PAYSTACK_SECRET_KEY}"}
+
+    @classmethod
+    def create_subaccount(
+        cls,
+        *,
+        business_name: str,
+        bank_code: str,
+        account_number: str,
+        percentage_charge: float,
+    ) -> Dict[str, Any]:
+        """Create a Paystack subaccount for a seller."""
+        payload = {
+            "business_name": business_name,
+            "settlement_bank": bank_code,
+            "account_number": account_number,
+            "percentage_charge": percentage_charge,
+            "description": f"Markt seller subaccount for {business_name}",
+        }
+        response = requests.post(
+            f"{cls.BASE_URL}/subaccount",
+            json=payload,
+            headers=cls._headers(),
+            timeout=30,
+        )
+        data = response.json()
+        if response.status_code != 200 or not data.get("status"):
+            logger.error("Paystack subaccount creation failed: %s", data)
+            raise APIError("Failed to create seller payout account", 502)
+        return data["data"]

--- a/app/wallet/paystack_transfers.py
+++ b/app/wallet/paystack_transfers.py
@@ -1,0 +1,81 @@
+"""Paystack Transfer API helpers for wallet withdrawals."""
+
+import logging
+from typing import Any, Dict
+
+import requests
+
+from app.libs.errors import APIError
+
+logger = logging.getLogger(__name__)
+
+
+class PaystackTransferClient:
+    BASE_URL = "https://api.paystack.co"
+
+    @classmethod
+    def _headers(cls) -> Dict[str, str]:
+        from app.payments.services import PaymentService
+
+        if not PaymentService.PAYSTACK_SECRET_KEY:
+            raise APIError("Paystack is not configured", 503)
+        return {"Authorization": f"Bearer {PaymentService.PAYSTACK_SECRET_KEY}"}
+
+    @classmethod
+    def create_transfer_recipient(
+        cls,
+        *,
+        account_name: str,
+        account_number: str,
+        bank_code: str,
+        currency: str = "NGN",
+    ) -> str:
+        payload = {
+            "type": "nuban",
+            "name": account_name,
+            "account_number": account_number,
+            "bank_code": bank_code,
+            "currency": currency,
+        }
+        response = requests.post(
+            f"{cls.BASE_URL}/transferrecipient",
+            json=payload,
+            headers=cls._headers(),
+            timeout=30,
+        )
+        data = response.json()
+        if response.status_code != 200 or not data.get("status"):
+            logger.error("Paystack recipient creation failed: %s", data)
+            raise APIError("Failed to verify bank account with Paystack", 502)
+
+        return data["data"]["recipient_code"]
+
+    @classmethod
+    def initiate_transfer(
+        cls,
+        *,
+        amount_kobo: int,
+        recipient_code: str,
+        reference: str,
+        reason: str = "Markt wallet withdrawal",
+    ) -> Dict[str, Any]:
+        payload = {
+            "source": "balance",
+            "amount": amount_kobo,
+            "recipient": recipient_code,
+            "reason": reason,
+            "reference": reference,
+        }
+        response = requests.post(
+            f"{cls.BASE_URL}/transfer",
+            json=payload,
+            headers=cls._headers(),
+            timeout=30,
+        )
+        data = response.json()
+        if response.status_code != 200 or not data.get("status"):
+            logger.error("Paystack transfer failed: %s", data)
+            message = data.get("message", "Transfer initiation failed")
+            raise APIError(message, 502)
+
+        return data

--- a/app/wallet/routes.py
+++ b/app/wallet/routes.py
@@ -1,0 +1,61 @@
+from flask.views import MethodView
+from flask_login import current_user, login_required
+from flask_smorest import Blueprint, abort
+
+from app.libs.errors import APIError
+from app.libs.schemas import PaginationQueryArgs
+
+from .schemas import (
+    WalletBalanceSchema,
+    WalletTransactionsResponseSchema,
+    WithdrawalRequestSchema,
+    WithdrawalResponseSchema,
+)
+from .services import WalletService
+
+bp = Blueprint(
+    "wallet", __name__, description="User wallet operations", url_prefix="/wallet"
+)
+
+
+@bp.route("/")
+class WalletBalance(MethodView):
+    @login_required
+    @bp.response(200, WalletBalanceSchema)
+    def get(self):
+        """Get current user's wallet balance"""
+        try:
+            return WalletService.get_balance(current_user.id)
+        except APIError as e:
+            abort(e.status_code, message=e.message)
+
+
+@bp.route("/transactions")
+class WalletTransactions(MethodView):
+    @login_required
+    @bp.arguments(PaginationQueryArgs, location="query")
+    @bp.response(200, WalletTransactionsResponseSchema)
+    def get(self, args):
+        """List wallet transaction history"""
+        try:
+            return WalletService.list_transactions(
+                current_user.id,
+                page=args.get("page", 1),
+                per_page=args.get("per_page", 20),
+            )
+        except APIError as e:
+            abort(e.status_code, message=e.message)
+
+
+@bp.route("/withdraw")
+class WalletWithdraw(MethodView):
+    @login_required
+    @bp.arguments(WithdrawalRequestSchema)
+    @bp.response(201, WithdrawalResponseSchema)
+    def post(self, data):
+        """Request a withdrawal to a bank account (queued for Paystack transfer)"""
+        try:
+            withdrawal = WalletService.request_withdrawal(current_user.id, data)
+            return withdrawal
+        except APIError as e:
+            abort(e.status_code, message=e.message)

--- a/app/wallet/routes.py
+++ b/app/wallet/routes.py
@@ -10,6 +10,11 @@ from .schemas import (
     WalletTransactionsResponseSchema,
     WithdrawalRequestSchema,
     WithdrawalResponseSchema,
+    WithdrawalListResponseSchema,
+    TopUpInitializeSchema,
+    TopUpInitializeResponseSchema,
+    SellerPayoutAccountSchema,
+    SellerPayoutAccountResponseSchema,
 )
 from .services import WalletService
 
@@ -53,9 +58,64 @@ class WalletWithdraw(MethodView):
     @bp.arguments(WithdrawalRequestSchema)
     @bp.response(201, WithdrawalResponseSchema)
     def post(self, data):
-        """Request a withdrawal to a bank account (queued for Paystack transfer)"""
+        """Request a withdrawal to a bank account via Paystack transfer"""
         try:
             withdrawal = WalletService.request_withdrawal(current_user.id, data)
             return withdrawal
+        except APIError as e:
+            abort(e.status_code, message=e.message)
+
+
+@bp.route("/withdrawals")
+class WalletWithdrawals(MethodView):
+    @login_required
+    @bp.arguments(PaginationQueryArgs, location="query")
+    @bp.response(200, WithdrawalListResponseSchema)
+    def get(self, args):
+        """List withdrawal requests for the current user"""
+        try:
+            return WalletService.list_withdrawals(
+                current_user.id,
+                page=args.get("page", 1),
+                per_page=args.get("per_page", 20),
+            )
+        except APIError as e:
+            abort(e.status_code, message=e.message)
+
+
+@bp.route("/topup/initialize")
+class WalletTopUpInitialize(MethodView):
+    @login_required
+    @bp.arguments(TopUpInitializeSchema)
+    @bp.response(201, TopUpInitializeResponseSchema)
+    def post(self, data):
+        """Initialize a Paystack wallet top-up"""
+        try:
+            return WalletService.initialize_topup(
+                current_user.id,
+                data["amount"],
+                currency=data.get("currency", "NGN"),
+                platform=data.get("platform", "web"),
+            )
+        except APIError as e:
+            abort(e.status_code, message=e.message)
+
+
+@bp.route("/seller/payout-account")
+class SellerPayoutAccount(MethodView):
+    @login_required
+    @bp.arguments(SellerPayoutAccountSchema)
+    @bp.response(201, SellerPayoutAccountResponseSchema)
+    def post(self, data):
+        """Register seller bank account for Paystack split settlements"""
+        try:
+            if not current_user.is_seller or not current_user.seller_account:
+                abort(403, message="Seller account required")
+            return WalletService.register_seller_payout_account(
+                current_user.seller_account.id,
+                bank_code=data["bank_code"],
+                account_number=data["account_number"],
+                account_name=data["account_name"],
+            )
         except APIError as e:
             abort(e.status_code, message=e.message)

--- a/app/wallet/schemas.py
+++ b/app/wallet/schemas.py
@@ -1,0 +1,38 @@
+from marshmallow import Schema, fields, validate
+
+
+class WalletBalanceSchema(Schema):
+    currency = fields.Str()
+    available_balance = fields.Float()
+
+
+class WalletTransactionSchema(Schema):
+    id = fields.Int()
+    type = fields.Str()
+    amount = fields.Float()
+    balance_after = fields.Float()
+    reference_type = fields.Str()
+    reference_id = fields.Str()
+    description = fields.Str()
+    created_at = fields.Str()
+
+
+class WalletTransactionsResponseSchema(Schema):
+    transactions = fields.Nested(WalletTransactionSchema, many=True)
+    pagination = fields.Dict()
+
+
+class WithdrawalRequestSchema(Schema):
+    amount = fields.Float(required=True, validate=validate.Range(min=1))
+    currency = fields.Str(missing="NGN")
+    bank_code = fields.Str(required=True)
+    account_number = fields.Str(required=True)
+    account_name = fields.Str(required=True)
+
+
+class WithdrawalResponseSchema(Schema):
+    id = fields.Str()
+    amount = fields.Float()
+    currency = fields.Str()
+    status = fields.Str()
+    created_at = fields.DateTime()

--- a/app/wallet/schemas.py
+++ b/app/wallet/schemas.py
@@ -30,9 +30,41 @@ class WithdrawalRequestSchema(Schema):
     account_name = fields.Str(required=True)
 
 
+class WithdrawalListResponseSchema(Schema):
+    withdrawals = fields.List(fields.Dict())
+    pagination = fields.Dict()
+
+
 class WithdrawalResponseSchema(Schema):
     id = fields.Str()
     amount = fields.Float()
     currency = fields.Str()
     status = fields.Str()
     created_at = fields.DateTime()
+
+
+class TopUpInitializeSchema(Schema):
+    amount = fields.Float(required=True, validate=validate.Range(min=100))
+    currency = fields.Str(missing="NGN")
+    platform = fields.Str(missing="web")
+
+
+class TopUpInitializeResponseSchema(Schema):
+    topup_id = fields.Str()
+    amount = fields.Float()
+    currency = fields.Str()
+    authorization_url = fields.Str()
+    reference = fields.Str()
+
+
+class SellerPayoutAccountSchema(Schema):
+    bank_code = fields.Str(required=True)
+    account_number = fields.Str(required=True)
+    account_name = fields.Str(required=True)
+
+
+class SellerPayoutAccountResponseSchema(Schema):
+    seller_id = fields.Int()
+    subaccount_code = fields.Str()
+    account_name = fields.Str()
+    account_number_masked = fields.Str()

--- a/app/wallet/services.py
+++ b/app/wallet/services.py
@@ -2,7 +2,7 @@ import logging
 import uuid
 from typing import Any, Dict, Optional
 
-from app.libs.errors import ValidationError
+from app.libs.errors import APIError, NotFoundError, ValidationError, ConflictError
 from app.libs.session import session_scope
 from app.orders.models import OrderItem
 
@@ -11,9 +11,13 @@ from .models import (
     WalletEntry,
     WalletEntryType,
     WalletReferenceType,
+    WalletTopUp,
+    TopUpStatus,
     WithdrawalRequest,
     WithdrawalStatus,
 )
+from .paystack_transfers import PaystackTransferClient
+from .paystack_subaccounts import PaystackSubaccountClient
 
 logger = logging.getLogger(__name__)
 
@@ -173,6 +177,13 @@ class WalletService:
         order_item: OrderItem, commission_rate: float = DEFAULT_COMMISSION_RATE
     ) -> Optional[WalletEntry]:
         """Credit seller wallet when an order item is delivered."""
+        from app.orders.models import Order
+
+        with session_scope() as session:
+            order = session.query(Order).get(order_item.order_id)
+            if order and order.paystack_split_used:
+                return None
+
         if not order_item.seller or not order_item.seller.user_id:
             return None
 
@@ -248,5 +259,364 @@ class WalletService:
             currency=currency,
         )
 
+        try:
+            from app.wallet.tasks import process_withdrawal
+
+            process_withdrawal.delay(withdrawal_id)
+        except Exception as exc:
+            logger.warning(
+                "Async withdrawal dispatch failed for %s: %s", withdrawal_id, exc
+            )
+            try:
+                return WalletService.process_withdrawal(withdrawal_id)
+            except APIError:
+                pass
+
         with session_scope() as session:
             return session.query(WithdrawalRequest).get(withdrawal_id)
+
+    @staticmethod
+    def list_withdrawals(
+        user_id: str, page: int = 1, per_page: int = 20
+    ) -> Dict[str, Any]:
+        with session_scope() as session:
+            query = (
+                session.query(WithdrawalRequest)
+                .filter_by(user_id=user_id)
+                .order_by(WithdrawalRequest.created_at.desc())
+            )
+            total = query.count()
+            rows = query.offset((page - 1) * per_page).limit(per_page).all()
+            return {
+                "withdrawals": [
+                    {
+                        "id": row.id,
+                        "amount": row.amount,
+                        "currency": row.currency,
+                        "status": row.status.value,
+                        "account_name": row.account_name,
+                        "account_number": row.account_number[-4:].rjust(
+                            len(row.account_number), "*"
+                        ),
+                        "paystack_transfer_ref": row.paystack_transfer_ref,
+                        "failure_reason": row.failure_reason,
+                        "created_at": row.created_at.isoformat()
+                        if row.created_at
+                        else None,
+                    }
+                    for row in rows
+                ],
+                "pagination": {
+                    "page": page,
+                    "per_page": per_page,
+                    "total_items": total,
+                    "total_pages": (total + per_page - 1) // per_page,
+                },
+            }
+
+    @staticmethod
+    def process_withdrawal(withdrawal_id: str) -> WithdrawalRequest:
+        """Submit a pending withdrawal to Paystack Transfer API."""
+        with session_scope() as session:
+            withdrawal = session.query(WithdrawalRequest).get(withdrawal_id)
+            if not withdrawal:
+                raise NotFoundError("Withdrawal request not found")
+            if withdrawal.status != WithdrawalStatus.PENDING:
+                return withdrawal
+
+            withdrawal.status = WithdrawalStatus.PROCESSING
+            session.flush()
+
+            amount = withdrawal.amount
+            bank_code = withdrawal.bank_code
+            account_number = withdrawal.account_number
+            account_name = withdrawal.account_name
+            currency = withdrawal.currency
+            user_id = withdrawal.user_id
+
+        try:
+            recipient_code = PaystackTransferClient.create_transfer_recipient(
+                account_name=account_name,
+                account_number=account_number,
+                bank_code=bank_code,
+                currency=currency,
+            )
+            transfer_data = PaystackTransferClient.initiate_transfer(
+                amount_kobo=int(round(amount * 100)),
+                recipient_code=recipient_code,
+                reference=withdrawal_id,
+            )
+            transfer_ref = transfer_data.get("data", {}).get("reference", withdrawal_id)
+
+            with session_scope() as session:
+                withdrawal = session.query(WithdrawalRequest).get(withdrawal_id)
+                withdrawal.paystack_transfer_ref = transfer_ref
+                session.flush()
+                return withdrawal
+
+        except APIError as exc:
+            WalletService._fail_withdrawal(
+                withdrawal_id, user_id, amount, currency, str(exc.message)
+            )
+            raise
+
+    @staticmethod
+    def _fail_withdrawal(
+        withdrawal_id: str,
+        user_id: str,
+        amount: float,
+        currency: str,
+        reason: str,
+    ):
+        """Mark withdrawal failed and refund debited amount to wallet."""
+        WalletService.credit(
+            user_id,
+            amount,
+            WalletReferenceType.ADJUSTMENT,
+            withdrawal_id,
+            description=f"Withdrawal failed: {reason}",
+            idempotency_key=f"withdraw-refund:{withdrawal_id}",
+            currency=currency,
+        )
+        with session_scope() as session:
+            withdrawal = session.query(WithdrawalRequest).get(withdrawal_id)
+            if withdrawal:
+                withdrawal.status = WithdrawalStatus.FAILED
+                withdrawal.failure_reason = reason[:255]
+
+    @staticmethod
+    def complete_withdrawal_transfer(reference: str) -> bool:
+        with session_scope() as session:
+            withdrawal = (
+                session.query(WithdrawalRequest)
+                .filter(
+                    (WithdrawalRequest.id == reference)
+                    | (WithdrawalRequest.paystack_transfer_ref == reference)
+                )
+                .first()
+            )
+            if not withdrawal:
+                logger.warning("Withdrawal not found for transfer ref %s", reference)
+                return False
+            if withdrawal.status == WithdrawalStatus.COMPLETED:
+                return True
+            withdrawal.status = WithdrawalStatus.COMPLETED
+            return True
+
+    @staticmethod
+    def fail_withdrawal_transfer(reference: str, reason: str = "") -> bool:
+        with session_scope() as session:
+            withdrawal = (
+                session.query(WithdrawalRequest)
+                .filter(
+                    (WithdrawalRequest.id == reference)
+                    | (WithdrawalRequest.paystack_transfer_ref == reference)
+                )
+                .first()
+            )
+            if not withdrawal:
+                return False
+            if withdrawal.status == WithdrawalStatus.FAILED:
+                return True
+
+            user_id = withdrawal.user_id
+            amount = withdrawal.amount
+            currency = withdrawal.currency
+            withdrawal_id = withdrawal.id
+
+        WalletService._fail_withdrawal(
+            withdrawal_id, user_id, amount, currency, reason or "Transfer failed"
+        )
+        return True
+
+    @staticmethod
+    def pay_for_order(
+        user_id: str,
+        order_id: str,
+        payment_id: str,
+        amount: float,
+        currency: str = "NGN",
+    ) -> WalletEntry:
+        """Debit buyer wallet for an order payment."""
+        return WalletService.debit(
+            user_id,
+            amount,
+            WalletReferenceType.ORDER_PAYMENT,
+            payment_id,
+            description=f"Wallet payment for order {order_id}",
+            idempotency_key=f"pay:wallet:{payment_id}",
+            currency=currency,
+        )
+
+    @staticmethod
+    def initialize_topup(
+        user_id: str,
+        amount: float,
+        currency: str = "NGN",
+        *,
+        platform: str = "web",
+    ) -> Dict[str, Any]:
+        """Create a pending top-up and return Paystack authorization URL."""
+        import requests
+        from app.payments.services import PaymentService
+        from app.users.models import User
+        from main.config import settings
+
+        if amount < 100:
+            raise ValidationError("Minimum top-up amount is 100")
+
+        topup_id = None
+        with session_scope() as session:
+            user = session.query(User).get(user_id)
+            if not user:
+                raise NotFoundError("User not found")
+
+            topup = WalletTopUp(
+                user_id=user_id,
+                amount=round(amount, 2),
+                currency=currency,
+                status=TopUpStatus.PENDING,
+            )
+            session.add(topup)
+            session.flush()
+            topup_id = topup.id
+            user_email = user.email
+
+        reference = f"TOP_{topup_id}"
+        base_url = settings.API_BASE_URL or "http://localhost:8000"
+        callback_url = (
+            f"{base_url}/api/v1/wallet/topup/callback/{topup_id}"
+            f"?platform={platform}"
+        )
+
+        payload = {
+            "amount": int(round(amount * 100)),
+            "email": user_email,
+            "currency": currency,
+            "reference": reference,
+            "callback_url": callback_url,
+            "metadata": {
+                "type": "wallet_topup",
+                "topup_id": topup_id,
+                "user_id": user_id,
+            },
+        }
+
+        response = requests.post(
+            f"{PaymentService.PAYSTACK_BASE_URL}/transaction/initialize",
+            json=payload,
+            headers={"Authorization": f"Bearer {PaymentService.PAYSTACK_SECRET_KEY}"},
+            timeout=30,
+        )
+        data = response.json()
+        if response.status_code != 200 or not data.get("status"):
+            with session_scope() as session:
+                topup = session.query(WalletTopUp).get(topup_id)
+                if topup:
+                    topup.status = TopUpStatus.FAILED
+            raise APIError("Failed to initialize wallet top-up", 502)
+
+        auth_url = data["data"]["authorization_url"]
+        paystack_ref = data["data"]["reference"]
+
+        with session_scope() as session:
+            topup = session.query(WalletTopUp).get(topup_id)
+            topup.paystack_reference = paystack_ref
+            session.flush()
+
+        return {
+            "topup_id": topup_id,
+            "amount": amount,
+            "currency": currency,
+            "authorization_url": auth_url,
+            "reference": paystack_ref,
+        }
+
+    @staticmethod
+    def complete_topup(
+        reference: str, gateway_response: Optional[Dict[str, Any]] = None
+    ) -> bool:
+        """Idempotently credit wallet after successful Paystack top-up."""
+        topup_id = (
+            reference.replace("TOP_", "", 1) if reference.startswith("TOP_") else None
+        )
+
+        with session_scope() as session:
+            if topup_id:
+                topup = session.query(WalletTopUp).get(topup_id)
+            else:
+                topup = (
+                    session.query(WalletTopUp)
+                    .filter_by(paystack_reference=reference)
+                    .first()
+                )
+
+            if not topup:
+                logger.warning("Top-up not found for reference %s", reference)
+                return False
+
+            if topup.status == TopUpStatus.COMPLETED:
+                return True
+
+            user_id = topup.user_id
+            amount = topup.amount
+            currency = topup.currency
+            topup_ref = topup.id
+            topup.status = TopUpStatus.COMPLETED
+            session.flush()
+
+        WalletService.credit(
+            user_id,
+            amount,
+            WalletReferenceType.WALLET_TOPUP,
+            topup_ref,
+            description=f"Wallet top-up {topup_ref}",
+            idempotency_key=f"topup:{topup_ref}",
+            currency=currency,
+        )
+        return True
+
+    @staticmethod
+    def register_seller_payout_account(
+        seller_id: int,
+        *,
+        bank_code: str,
+        account_number: str,
+        account_name: str,
+    ) -> Dict[str, Any]:
+        """Register seller bank details and create Paystack subaccount."""
+        from app.users.models import Seller
+        from main.config import settings
+
+        with session_scope() as session:
+            seller = session.query(Seller).get(seller_id)
+            if not seller:
+                raise NotFoundError("Seller not found")
+            if seller.paystack_subaccount_code:
+                raise ConflictError("Seller payout account already registered")
+
+            shop_name = seller.shop_name or f"Seller {seller_id}"
+            commission_pct = round(settings.PLATFORM_COMMISSION_RATE * 100, 2)
+
+        subaccount = PaystackSubaccountClient.create_subaccount(
+            business_name=shop_name,
+            bank_code=bank_code,
+            account_number=account_number,
+            percentage_charge=commission_pct,
+        )
+
+        with session_scope() as session:
+            seller = session.query(Seller).get(seller_id)
+            seller.paystack_subaccount_code = subaccount["subaccount_code"]
+            seller.payout_bank_code = bank_code
+            seller.payout_account_number = account_number
+            seller.payout_account_name = account_name
+            session.flush()
+            return {
+                "seller_id": seller.id,
+                "subaccount_code": seller.paystack_subaccount_code,
+                "account_name": seller.payout_account_name,
+                "account_number_masked": account_number[-4:].rjust(
+                    len(account_number), "*"
+                ),
+            }

--- a/app/wallet/services.py
+++ b/app/wallet/services.py
@@ -1,0 +1,252 @@
+import logging
+import uuid
+from typing import Any, Dict, Optional
+
+from app.libs.errors import ValidationError
+from app.libs.session import session_scope
+from app.orders.models import OrderItem
+
+from .models import (
+    WalletAccount,
+    WalletEntry,
+    WalletEntryType,
+    WalletReferenceType,
+    WithdrawalRequest,
+    WithdrawalStatus,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_COMMISSION_RATE = 0.10
+MIN_WITHDRAWAL_AMOUNT = 1000.0
+
+
+class WalletService:
+    @staticmethod
+    def _get_or_create_account(
+        session, user_id: str, currency: str = "NGN"
+    ) -> WalletAccount:
+        account = (
+            session.query(WalletAccount)
+            .filter_by(user_id=user_id, currency=currency)
+            .first()
+        )
+        if not account:
+            account = WalletAccount(
+                user_id=user_id, currency=currency, available_balance=0.0
+            )
+            session.add(account)
+            session.flush()
+        return account
+
+    @staticmethod
+    def get_balance(user_id: str, currency: str = "NGN") -> Dict[str, Any]:
+        with session_scope() as session:
+            account = WalletService._get_or_create_account(session, user_id, currency)
+            return {
+                "currency": account.currency,
+                "available_balance": round(account.available_balance, 2),
+            }
+
+    @staticmethod
+    def list_transactions(
+        user_id: str, page: int = 1, per_page: int = 20
+    ) -> Dict[str, Any]:
+        with session_scope() as session:
+            account = WalletService._get_or_create_account(session, user_id)
+            query = (
+                session.query(WalletEntry)
+                .filter_by(wallet_account_id=account.id)
+                .order_by(WalletEntry.created_at.desc())
+            )
+            total = query.count()
+            entries = query.offset((page - 1) * per_page).limit(per_page).all()
+            return {
+                "transactions": [
+                    {
+                        "id": entry.id,
+                        "type": entry.entry_type.value,
+                        "amount": entry.amount,
+                        "balance_after": entry.balance_after,
+                        "reference_type": entry.reference_type.value,
+                        "reference_id": entry.reference_id,
+                        "description": entry.description,
+                        "created_at": entry.created_at.isoformat()
+                        if entry.created_at
+                        else None,
+                    }
+                    for entry in entries
+                ],
+                "pagination": {
+                    "page": page,
+                    "per_page": per_page,
+                    "total_items": total,
+                    "total_pages": (total + per_page - 1) // per_page,
+                },
+            }
+
+    @staticmethod
+    def credit(
+        user_id: str,
+        amount: float,
+        reference_type: WalletReferenceType,
+        reference_id: str,
+        *,
+        description: Optional[str] = None,
+        idempotency_key: Optional[str] = None,
+        currency: str = "NGN",
+    ) -> WalletEntry:
+        if amount <= 0:
+            raise ValidationError("Credit amount must be positive")
+
+        with session_scope() as session:
+            if idempotency_key:
+                existing = (
+                    session.query(WalletEntry)
+                    .filter_by(idempotency_key=idempotency_key)
+                    .first()
+                )
+                if existing:
+                    return existing
+
+            account = WalletService._get_or_create_account(session, user_id, currency)
+            account.available_balance = round(account.available_balance + amount, 2)
+            entry = WalletEntry(
+                wallet_account_id=account.id,
+                entry_type=WalletEntryType.CREDIT,
+                amount=round(amount, 2),
+                balance_after=account.available_balance,
+                reference_type=reference_type,
+                reference_id=reference_id,
+                description=description,
+                idempotency_key=idempotency_key or str(uuid.uuid4()),
+            )
+            session.add(entry)
+            session.flush()
+            return entry
+
+    @staticmethod
+    def debit(
+        user_id: str,
+        amount: float,
+        reference_type: WalletReferenceType,
+        reference_id: str,
+        *,
+        description: Optional[str] = None,
+        idempotency_key: Optional[str] = None,
+        currency: str = "NGN",
+    ) -> WalletEntry:
+        if amount <= 0:
+            raise ValidationError("Debit amount must be positive")
+
+        with session_scope() as session:
+            if idempotency_key:
+                existing = (
+                    session.query(WalletEntry)
+                    .filter_by(idempotency_key=idempotency_key)
+                    .first()
+                )
+                if existing:
+                    return existing
+
+            account = WalletService._get_or_create_account(session, user_id, currency)
+            if account.available_balance < amount:
+                raise ValidationError("Insufficient wallet balance")
+
+            account.available_balance = round(account.available_balance - amount, 2)
+            entry = WalletEntry(
+                wallet_account_id=account.id,
+                entry_type=WalletEntryType.DEBIT,
+                amount=round(amount, 2),
+                balance_after=account.available_balance,
+                reference_type=reference_type,
+                reference_id=reference_id,
+                description=description,
+                idempotency_key=idempotency_key or str(uuid.uuid4()),
+            )
+            session.add(entry)
+            session.flush()
+            return entry
+
+    @staticmethod
+    def settle_order_item(
+        order_item: OrderItem, commission_rate: float = DEFAULT_COMMISSION_RATE
+    ) -> Optional[WalletEntry]:
+        """Credit seller wallet when an order item is delivered."""
+        if not order_item.seller or not order_item.seller.user_id:
+            return None
+
+        gross = (order_item.price or 0) * (order_item.quantity or 0)
+        if gross <= 0:
+            return None
+
+        net = round(gross * (1 - commission_rate), 2)
+        if net <= 0:
+            return None
+
+        return WalletService.credit(
+            order_item.seller.user_id,
+            net,
+            WalletReferenceType.ORDER_SETTLEMENT,
+            str(order_item.id),
+            description=f"Settlement for order item {order_item.id}",
+            idempotency_key=f"settle:item:{order_item.id}",
+        )
+
+    @staticmethod
+    def refund_order_to_wallet(
+        buyer_user_id: str,
+        order_id: str,
+        amount: float,
+    ) -> WalletEntry:
+        return WalletService.credit(
+            buyer_user_id,
+            amount,
+            WalletReferenceType.ORDER_REFUND,
+            order_id,
+            description=f"Refund for cancelled order {order_id}",
+            idempotency_key=f"refund:order:{order_id}",
+        )
+
+    @staticmethod
+    def request_withdrawal(user_id: str, data: Dict[str, Any]) -> WithdrawalRequest:
+        amount = float(data["amount"])
+        if amount < MIN_WITHDRAWAL_AMOUNT:
+            raise ValidationError(
+                f"Minimum withdrawal amount is {MIN_WITHDRAWAL_AMOUNT}"
+            )
+
+        withdrawal_id = None
+        currency = data.get("currency", "NGN")
+
+        with session_scope() as session:
+            account = WalletService._get_or_create_account(session, user_id, currency)
+            if account.available_balance < amount:
+                raise ValidationError("Insufficient wallet balance for withdrawal")
+
+            withdrawal = WithdrawalRequest(
+                user_id=user_id,
+                amount=amount,
+                currency=account.currency,
+                bank_code=data["bank_code"],
+                account_number=data["account_number"],
+                account_name=data["account_name"],
+                status=WithdrawalStatus.PENDING,
+            )
+            session.add(withdrawal)
+            session.flush()
+            withdrawal_id = withdrawal.id
+            currency = withdrawal.currency
+
+        WalletService.debit(
+            user_id,
+            amount,
+            WalletReferenceType.WITHDRAWAL,
+            withdrawal_id,
+            description="Withdrawal request",
+            idempotency_key=f"withdraw:{withdrawal_id}",
+            currency=currency,
+        )
+
+        with session_scope() as session:
+            return session.query(WithdrawalRequest).get(withdrawal_id)

--- a/app/wallet/tasks.py
+++ b/app/wallet/tasks.py
@@ -1,0 +1,26 @@
+"""Celery tasks for wallet operations."""
+
+import logging
+
+from main.workers import celery_app
+
+logger = logging.getLogger(__name__)
+
+
+@celery_app.task(
+    name="app.wallet.tasks.process_withdrawal",
+    bind=True,
+    max_retries=3,
+    queue="default",
+)
+def process_withdrawal(self, withdrawal_id: str):
+    """Process a pending withdrawal via Paystack Transfer API."""
+    from app.wallet.services import WalletService
+
+    try:
+        WalletService.process_withdrawal(withdrawal_id)
+    except Exception as exc:
+        logger.error("Withdrawal task failed for %s: %s", withdrawal_id, exc)
+        if self.request.retries < self.max_retries:
+            raise self.retry(countdown=60 * (2**self.request.retries))
+        raise

--- a/main/config.py
+++ b/main/config.py
@@ -118,6 +118,13 @@ class Config:
         self.CELERY_WORKER_DISABLE_RATE_LIMITS = False
         self.CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
 
+        self.UNPAID_ORDER_EXPIRY_HOURS = config(
+            "UNPAID_ORDER_EXPIRY_HOURS", default=48, cast=int
+        )
+        self.PLATFORM_COMMISSION_RATE = config(
+            "PLATFORM_COMMISSION_RATE", default=0.10, cast=float
+        )
+
     @property
     def SQLALCHEMY_DATABASE_URI(self):
         return f"postgresql+psycopg2://{self.DB_USER}:{self.DB_PASSWORD}@{self.DB_HOST}:{self.DB_PORT}/{self.DB_NAME}"

--- a/main/config.py
+++ b/main/config.py
@@ -73,13 +73,18 @@ class Config:
             default="http://localhost:8000" if self.ENV == "development" else "",
         )
 
-        # Frontend Base URL for payment redirects
-        # For production: https://yourdomain.com or https://app.yourdomain.com
+        # Web app base URL for payment redirects
+        # For production: https://marktcommerce.com/app
         # For development: http://localhost:3000
-        self.FRONTEND_BASE_URL = config(
-            "FRONTEND_BASE_URL",
-            default="http://localhost:3000" if self.ENV == "development" else "",
+        self.WEB_APP_BASE_URL = config(
+            "WEB_APP_BASE_URL",
+            default="http://localhost:3000"
+            if self.ENV == "development"
+            else "https://marktcommerce.com/app",
         )
+
+        # Mobile app deep link scheme for payment redirects (e.g. markt://)
+        self.MOBILE_APP_SCHEME = config("MOBILE_APP_SCHEME", default="markt://")
 
         # AWS Configuration
         self.AWS_ACCESS_KEY = config("AWS_ACCESS_KEY", default="")

--- a/main/routes.py
+++ b/main/routes.py
@@ -30,8 +30,10 @@ def register_blueprints(app, api):
             mod = import_module(f"app.{module}.routes")
             bp = getattr(mod, "bp", None) or getattr(mod, f"{module}_bp")
 
-            # Add URL prefix to each blueprint
-            bp.url_prefix = "/api/v1" + (bp.url_prefix or "")
+            # Add URL prefix to each blueprint (idempotent across app factory calls)
+            prefix = bp.url_prefix or ""
+            if not prefix.startswith("/api/v1"):
+                bp.url_prefix = f"/api/v1{prefix}"
 
             api.register_blueprint(bp)
             logger.info(f"Registered blueprint for {module} at {bp.url_prefix}")

--- a/main/routes.py
+++ b/main/routes.py
@@ -23,6 +23,7 @@ def register_blueprints(app, api):
         "payments",
         "notifications",
         "health",
+        "wallet",
     ]
 
     for module in modules:

--- a/main/schedules.py
+++ b/main/schedules.py
@@ -56,4 +56,9 @@ CELERYBEAT_SCHEDULE = {
         "schedule": crontab(hour="*/4"),  # Every 4 hours
         "options": {"queue": "analytics"},
     },
+    "expire-unpaid-orders": {
+        "task": "app.orders.tasks.expire_unpaid_orders",
+        "schedule": crontab(hour="*/1"),  # Hourly
+        "options": {"queue": "default"},
+    },
 }

--- a/main/tasks.py
+++ b/main/tasks.py
@@ -23,8 +23,9 @@ def create_celery_app(app: Flask = None) -> Celery:
             "app.socials.tasks",
             "app.notifications.tasks",
             "app.media.tasks",
-            "app.realtime.tasks",  # New real-time tasks module
-            # add more task modules here
+            "app.realtime.tasks",
+            "app.orders.tasks",
+            "app.wallet.tasks",
         ]
     )
 

--- a/migrations/versions/b7c8d9e0f1a2_feat_wallet_and_order_cancellation.py
+++ b/migrations/versions/b7c8d9e0f1a2_feat_wallet_and_order_cancellation.py
@@ -1,0 +1,100 @@
+"""Revision ID: b7c8d9e0f1a2
+Revises: a1b2c3d4e5f6
+Create Date: 2026-06-25 18:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "b7c8d9e0f1a2"
+down_revision = "a1b2c3d4e5f6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("orders", sa.Column("cancelled_at", sa.DateTime(), nullable=True))
+    op.add_column("orders", sa.Column("cancel_reason", sa.Text(), nullable=True))
+
+    wallet_entry_type = sa.Enum(
+        "CREDIT", "DEBIT", name="walletentrytype"
+    )
+    wallet_reference_type = sa.Enum(
+        "ORDER_SETTLEMENT",
+        "ORDER_REFUND",
+        "WITHDRAWAL",
+        "ADJUSTMENT",
+        name="walletreferencetype",
+    )
+    withdrawal_status = sa.Enum(
+        "PENDING",
+        "PROCESSING",
+        "COMPLETED",
+        "FAILED",
+        name="withdrawalstatus",
+    )
+
+    wallet_entry_type.create(op.get_bind(), checkfirst=True)
+    wallet_reference_type.create(op.get_bind(), checkfirst=True)
+    withdrawal_status.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "wallet_accounts",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.String(length=12), nullable=False),
+        sa.Column("currency", sa.String(length=3), nullable=False),
+        sa.Column("available_balance", sa.Float(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id", "currency", name="uq_wallet_user_currency"),
+    )
+
+    op.create_table(
+        "wallet_entries",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("wallet_account_id", sa.Integer(), nullable=False),
+        sa.Column("entry_type", wallet_entry_type, nullable=False),
+        sa.Column("amount", sa.Float(), nullable=False),
+        sa.Column("balance_after", sa.Float(), nullable=False),
+        sa.Column("reference_type", wallet_reference_type, nullable=False),
+        sa.Column("reference_id", sa.String(length=50), nullable=False),
+        sa.Column("description", sa.String(length=255), nullable=True),
+        sa.Column("idempotency_key", sa.String(length=100), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["wallet_account_id"], ["wallet_accounts.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("idempotency_key"),
+    )
+
+    op.create_table(
+        "withdrawal_requests",
+        sa.Column("id", sa.String(length=12), nullable=False),
+        sa.Column("user_id", sa.String(length=12), nullable=False),
+        sa.Column("amount", sa.Float(), nullable=False),
+        sa.Column("currency", sa.String(length=3), nullable=False),
+        sa.Column("bank_code", sa.String(length=10), nullable=False),
+        sa.Column("account_number", sa.String(length=20), nullable=False),
+        sa.Column("account_name", sa.String(length=100), nullable=False),
+        sa.Column("status", withdrawal_status, nullable=False),
+        sa.Column("paystack_transfer_ref", sa.String(length=100), nullable=True),
+        sa.Column("failure_reason", sa.String(length=255), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade():
+    op.drop_table("withdrawal_requests")
+    op.drop_table("wallet_entries")
+    op.drop_table("wallet_accounts")
+    op.drop_column("orders", "cancel_reason")
+    op.drop_column("orders", "cancelled_at")
+    op.execute("DROP TYPE IF EXISTS withdrawalstatus")
+    op.execute("DROP TYPE IF EXISTS walletreferencetype")
+    op.execute("DROP TYPE IF EXISTS walletentrytype")

--- a/migrations/versions/c8d9e0f1a2b3_feat_wallet_add_order_payment_type.py
+++ b/migrations/versions/c8d9e0f1a2b3_feat_wallet_add_order_payment_type.py
@@ -1,0 +1,23 @@
+"""Add ORDER_PAYMENT to walletreferencetype enum.
+
+Revision ID: c8d9e0f1a2b3
+Revises: b7c8d9e0f1a2
+"""
+
+from alembic import op
+
+revision = "c8d9e0f1a2b3"
+down_revision = "b7c8d9e0f1a2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        "ALTER TYPE walletreferencetype "
+        "ADD VALUE IF NOT EXISTS 'ORDER_PAYMENT'"
+    )
+
+
+def downgrade():
+    pass

--- a/migrations/versions/d9e0f1a2b3c4_feat_phase3_topup_returns_subaccounts.py
+++ b/migrations/versions/d9e0f1a2b3c4_feat_phase3_topup_returns_subaccounts.py
@@ -1,0 +1,106 @@
+"""Phase 3: wallet top-ups, order returns, seller subaccounts.
+
+Revision ID: d9e0f1a2b3c4
+Revises: c8d9e0f1a2b3
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "d9e0f1a2b3c4"
+down_revision = "c8d9e0f1a2b3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        "ALTER TYPE walletreferencetype "
+        "ADD VALUE IF NOT EXISTS 'WALLET_TOPUP'"
+    )
+
+    op.add_column(
+        "orders",
+        sa.Column(
+            "paystack_split_used",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+    op.add_column(
+        "sellers",
+        sa.Column("paystack_subaccount_code", sa.String(length=50), nullable=True),
+    )
+    op.add_column(
+        "sellers",
+        sa.Column("payout_bank_code", sa.String(length=10), nullable=True),
+    )
+    op.add_column(
+        "sellers",
+        sa.Column("payout_account_number", sa.String(length=20), nullable=True),
+    )
+    op.add_column(
+        "sellers",
+        sa.Column("payout_account_name", sa.String(length=100), nullable=True),
+    )
+
+    order_return_status = sa.Enum(
+        "REQUESTED",
+        "APPROVED",
+        "REJECTED",
+        "REFUNDED",
+        name="orderreturnstatus",
+    )
+    topup_status = sa.Enum(
+        "PENDING",
+        "COMPLETED",
+        "FAILED",
+        name="topupstatus",
+    )
+    order_return_status.create(op.get_bind(), checkfirst=True)
+    topup_status.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "order_returns",
+        sa.Column("id", sa.String(length=12), nullable=False),
+        sa.Column("order_id", sa.String(length=12), nullable=False),
+        sa.Column("buyer_id", sa.Integer(), nullable=False),
+        sa.Column("reason", sa.Text(), nullable=False),
+        sa.Column("status", order_return_status, nullable=False),
+        sa.Column("refund_amount", sa.Float(), nullable=True),
+        sa.Column("seller_notes", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["buyer_id"], ["buyers.id"]),
+        sa.ForeignKeyConstraint(["order_id"], ["orders.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "wallet_topups",
+        sa.Column("id", sa.String(length=12), nullable=False),
+        sa.Column("user_id", sa.String(length=12), nullable=False),
+        sa.Column("amount", sa.Float(), nullable=False),
+        sa.Column("currency", sa.String(length=3), nullable=False),
+        sa.Column("status", topup_status, nullable=False),
+        sa.Column("paystack_reference", sa.String(length=100), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("paystack_reference"),
+    )
+
+
+def downgrade():
+    op.drop_table("wallet_topups")
+    op.drop_table("order_returns")
+    op.drop_column("sellers", "payout_account_name")
+    op.drop_column("sellers", "payout_account_number")
+    op.drop_column("sellers", "payout_bank_code")
+    op.drop_column("sellers", "paystack_subaccount_code")
+    op.drop_column("orders", "paystack_split_used")
+    op.execute("DROP TYPE IF EXISTS topupstatus")
+    op.execute("DROP TYPE IF EXISTS orderreturnstatus")

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 testpaths = tests
 python_files = test_*.py
+pythonpath = .

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 django-debug-toolbar
 ipdb
-black
+black==22.12.0
 commitizen
 pre-commit
 flake8

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -5,3 +5,5 @@ black
 commitizen
 pre-commit
 flake8
+pytest
+pytest-mock

--- a/settings.ini.example
+++ b/settings.ini.example
@@ -51,10 +51,13 @@ PAYMENT_GATEWAY=paystack
 # Production: https://api.yourdomain.com
 API_BASE_URL=http://localhost:8000
 
-# Frontend URL (where users are redirected after payment)
+# Web app URL (where browser/web users are redirected after payment)
 # Development: http://localhost:3000
-# Production: https://yourdomain.com or https://app.yourdomain.com
-FRONTEND_BASE_URL=http://localhost:3000
+# Production: https://marktcommerce.com/app
+WEB_APP_BASE_URL=http://localhost:3000
+
+# Mobile app deep link scheme (where mobile app users are redirected after payment)
+MOBILE_APP_SCHEME=markt://
 
 # AWS Configuration
 AWS_ACCESS_KEY=your_aws_access_key_here

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,30 @@
+"""Pytest configuration for Markt backend tests."""
+
+import pytest
+
+
+def pytest_configure():
+    """Eager-import ORM modules so string-based relationships resolve in unit tests."""
+    import app.cart.models  # noqa: F401
+    import app.chats.models  # noqa: F401
+    import app.deliveries.models  # noqa: F401
+    import app.notifications.models  # noqa: F401
+    import app.orders.models  # noqa: F401
+    import app.payments.models  # noqa: F401
+    import app.products.models  # noqa: F401
+    import app.requests.models  # noqa: F401
+    import app.users.models  # noqa: F401
+
+
+@pytest.fixture
+def sample_shipping_address():
+    return {
+        "recipient_name": "Ada Lovelace",
+        "street_address": "12 Broad Street",
+        "city": "Lagos",
+        "state": "Lagos",
+        "postal_code": "100001",
+        "country": "Nigeria",
+        "latitude": 6.45,
+        "longitude": 3.39,
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ def pytest_configure():
     import app.products.models  # noqa: F401
     import app.requests.models  # noqa: F401
     import app.users.models  # noqa: F401
+    import app.wallet.models  # noqa: F401
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ def pytest_configure():
     import app.cart.models  # noqa: F401
     import app.chats.models  # noqa: F401
     import app.deliveries.models  # noqa: F401
+    import app.media.models  # noqa: F401
     import app.notifications.models  # noqa: F401
     import app.orders.models  # noqa: F401
     import app.payments.models  # noqa: F401

--- a/tests/test_api_smoke.py
+++ b/tests/test_api_smoke.py
@@ -1,0 +1,56 @@
+"""HTTP smoke tests for Phase 0 routes (Flask test client)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from main.setup import create_app
+
+
+@pytest.fixture
+def app():
+    flask_app, _socketio = create_app()
+    flask_app.config["TESTING"] = True
+    return flask_app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+class TestDeprecatedOrderCreateEndpoint:
+    @patch("flask_login.utils._get_user")
+    def test_post_orders_returns_410(self, mock_get_user, client):
+        user = MagicMock()
+        user.is_authenticated = True
+        user.is_buyer = True
+        user.buyer_account = MagicMock(id=1)
+        mock_get_user.return_value = user
+
+        response = client.post(
+            "/api/v1/orders/",
+            json={
+                "cart_id": 1,
+                "shipping_address": {"street": "x"},
+                "payment_method": "card",
+            },
+        )
+
+        assert response.status_code == 410
+        body = response.get_json()
+        assert "deprecated" in body["message"].lower()
+        assert body["replacement"] == "/api/v1/cart/checkout"
+        assert response.headers.get("Deprecation") == "true"
+
+
+class TestCheckoutAuthSmoke:
+    def test_checkout_requires_auth(self, client):
+        response = client.post(
+            "/api/v1/cart/checkout",
+            json={
+                "shipping_address": {},
+                "billing_address": {},
+            },
+        )
+        assert response.status_code == 401

--- a/tests/test_api_smoke.py
+++ b/tests/test_api_smoke.py
@@ -72,3 +72,9 @@ class TestOrderTrackAuthSmoke:
     def test_track_requires_auth(self, client):
         response = client.get("/api/v1/orders/ORD_TEST01/track")
         assert response.status_code == 401
+
+
+class TestWalletWithdrawalsAuthSmoke:
+    def test_withdrawals_requires_auth(self, client):
+        response = client.get("/api/v1/wallet/withdrawals")
+        assert response.status_code == 401

--- a/tests/test_api_smoke.py
+++ b/tests/test_api_smoke.py
@@ -54,3 +54,21 @@ class TestCheckoutAuthSmoke:
             },
         )
         assert response.status_code == 401
+
+
+class TestWalletAuthSmoke:
+    def test_wallet_requires_auth(self, client):
+        response = client.get("/api/v1/wallet/")
+        assert response.status_code == 401
+
+
+class TestOrderCancelAuthSmoke:
+    def test_cancel_requires_auth(self, client):
+        response = client.post("/api/v1/orders/ORD_TEST01/cancel", json={})
+        assert response.status_code == 401
+
+
+class TestOrderTrackAuthSmoke:
+    def test_track_requires_auth(self, client):
+        response = client.get("/api/v1/orders/ORD_TEST01/track")
+        assert response.status_code == 401

--- a/tests/test_checkout_phase0.py
+++ b/tests/test_checkout_phase0.py
@@ -1,0 +1,54 @@
+"""Smoke tests for Phase 0 checkout and order API behaviour."""
+
+from unittest.mock import patch
+
+import pytest
+
+from app.libs.errors import ValidationError
+from app.orders.shipping import normalize_shipping_address
+
+
+class TestCheckoutValidationSmoke:
+    """Fast validation checks that mirror checkout endpoint rules."""
+
+    def test_checkout_payload_with_docs_style_street_alias_fails_without_recipient(
+        self,
+    ):
+        with pytest.raises(ValidationError) as exc:
+            normalize_shipping_address(
+                {
+                    "street": "123 Main St",
+                    "city": "Lagos",
+                    "state": "Lagos",
+                    "country": "Nigeria",
+                    "postal_code": "100001",
+                }
+            )
+        assert "recipient_name" in exc.value.message
+
+    @patch("app.orders.shipping.geocode_address", return_value=(6.5, 3.4))
+    def test_checkout_payload_valid_with_recipient_and_street_alias(self, _mock_geo):
+        data = normalize_shipping_address(
+            {
+                "recipient_name": "Buyer One",
+                "street": "123 Main St",
+                "city": "Lagos",
+                "state": "Lagos",
+                "country": "Nigeria",
+                "postal_code": "100001",
+            }
+        )
+        assert data["street_address"] == "123 Main St"
+        assert data["recipient_name"] == "Buyer One"
+
+
+class TestDeprecatedOrderCreateRoute:
+    def test_deprecated_route_message_contract(self):
+        payload = {
+            "message": (
+                "POST /orders is deprecated. "
+                "Use POST /cart/checkout to create an order from the active cart."
+            ),
+            "replacement": "/api/v1/cart/checkout",
+        }
+        assert payload["replacement"] == "/api/v1/cart/checkout"

--- a/tests/test_order_expiry.py
+++ b/tests/test_order_expiry.py
@@ -1,0 +1,21 @@
+"""Tests for unpaid order expiry task."""
+
+from unittest.mock import MagicMock, patch
+
+from app.orders.models import OrderStatus
+from app.orders.tasks import expire_unpaid_orders
+
+
+@patch("app.orders.tasks.session_scope")
+def test_expire_unpaid_orders_cancels_stale(mock_session_scope):
+    stale_order = MagicMock()
+    stale_order.status = OrderStatus.PENDING_PAYMENT
+
+    session = MagicMock()
+    session.query.return_value.filter.return_value.all.return_value = [stale_order]
+    mock_session_scope.return_value.__enter__.return_value = session
+
+    result = expire_unpaid_orders()
+    assert result["expired"] == 1
+    assert stale_order.status == OrderStatus.CANCELLED
+    assert stale_order.cancel_reason is not None

--- a/tests/test_order_phase1.py
+++ b/tests/test_order_phase1.py
@@ -1,0 +1,15 @@
+"""Tests for Phase 1 order cancellation and tracking rules."""
+
+from app.orders.models import OrderStatus
+from app.orders.services import BUYER_CANCELLABLE_STATUSES
+
+
+def test_buyer_cancellable_statuses_include_pending_payment():
+    assert OrderStatus.PENDING_PAYMENT in BUYER_CANCELLABLE_STATUSES
+    assert OrderStatus.READY_FOR_DELIVERY in BUYER_CANCELLABLE_STATUSES
+
+
+def test_buyer_cannot_cancel_shipped_or_delivered():
+    assert OrderStatus.SHIPPED not in BUYER_CANCELLABLE_STATUSES
+    assert OrderStatus.DELIVERED not in BUYER_CANCELLABLE_STATUSES
+    assert OrderStatus.CANCELLED not in BUYER_CANCELLABLE_STATUSES

--- a/tests/test_payment_complete.py
+++ b/tests/test_payment_complete.py
@@ -1,0 +1,67 @@
+"""Unit tests for payment amount resolution and completion."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.libs.errors import ValidationError
+from app.orders.models import OrderStatus
+from app.payments.models import PaymentStatus
+from app.payments.services import PaymentService
+
+
+def test_resolve_order_payment_amount_uses_order_total():
+    order = SimpleNamespace(total=11500.0, subtotal=10000.0)
+    assert PaymentService._resolve_order_payment_amount(order, 11500.0) == 11500.0
+
+
+def test_resolve_order_payment_amount_rejects_mismatch():
+    order = SimpleNamespace(total=11500.0, subtotal=10000.0)
+    with pytest.raises(ValidationError) as exc:
+        PaymentService._resolve_order_payment_amount(order, 100.0)
+    assert "does not match order total" in exc.value.message
+
+
+def test_resolve_order_payment_amount_without_client_amount():
+    order = SimpleNamespace(total=5000.0, subtotal=4500.0)
+    assert PaymentService._resolve_order_payment_amount(order, None) == 5000.0
+
+
+@patch("app.payments.services.PaymentService._emit_payment_confirmed")
+@patch("app.payments.services.PaymentService._send_payment_notifications")
+@patch("app.payments.services.PaymentService._invalidate_payment_cache")
+@patch("app.products.services.ProductService.reduce_inventory_for_order")
+@patch("app.payments.services.session_scope")
+def test_complete_payment_is_idempotent(
+    mock_session_scope,
+    mock_reduce_inventory,
+    mock_invalidate_cache,
+    mock_notify,
+    mock_emit,
+):
+    payment = MagicMock()
+    payment.id = "PAY_TEST01"
+    payment.status = PaymentStatus.COMPLETED
+    payment.paid_at = None
+    payment.gateway_response = {}
+    payment.order_id = "ORD_TEST01"
+    payment.amount = 1000.0
+    payment.transaction_id = "ref-1"
+    payment.method = MagicMock(value="card")
+    payment.order = MagicMock(
+        status=OrderStatus.READY_FOR_DELIVERY,
+        order_number="ORD-1",
+        buyer=MagicMock(user_id="USR_1"),
+        items=[],
+    )
+
+    session = MagicMock()
+    mock_session_scope.return_value.__enter__.return_value = session
+    session.query.return_value.options.return_value.get.return_value = payment
+    session.query.return_value.filter_by.return_value.first.return_value = None
+
+    assert PaymentService.complete_payment(payment_id="PAY_TEST01") is True
+    mock_reduce_inventory.assert_not_called()
+    mock_notify.assert_not_called()
+    mock_emit.assert_not_called()

--- a/tests/test_phase2_payments.py
+++ b/tests/test_phase2_payments.py
@@ -1,0 +1,83 @@
+"""Tests for Phase 2 payment and wallet features."""
+
+import hashlib
+import hmac
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from app.payments.models import PaymentMethod
+from app.payments.services import PaymentService
+from app.wallet.models import WalletReferenceType
+from app.wallet.services import WalletService
+
+
+def test_verify_webhook_signature_uses_raw_body():
+    secret = "sk_test_secret"
+    body = b'{"event":"charge.success","data":{}}'
+    signature = hmac.new(secret.encode(), body, hashlib.sha512).hexdigest()
+
+    PaymentService.PAYSTACK_SECRET_KEY = secret
+    assert PaymentService._verify_webhook_signature(signature, body) is True
+    assert PaymentService._verify_webhook_signature(signature, b"{}") is False
+
+
+def test_wallet_payment_method_enum_exists():
+    assert PaymentMethod.WALLET.value == "wallet"
+
+
+@patch("app.payments.services.PaymentService.complete_payment")
+@patch("app.wallet.services.WalletService.pay_for_order")
+def test_create_payment_wallet_debits_and_completes(mock_pay, mock_complete):
+    mock_pay.return_value = MagicMock()
+    mock_complete.return_value = True
+
+    order = SimpleNamespace(
+        id="ORD_TEST01",
+        total=5000.0,
+        subtotal=5000.0,
+        buyer=SimpleNamespace(user_id="USR_BUYER1"),
+    )
+    payment = MagicMock()
+    payment.id = "PAY_TEST01"
+
+    session = MagicMock()
+    session.query.return_value.options.return_value.get.return_value = order
+    session.query.return_value.filter_by.return_value.first.return_value = None
+
+    captured_payment = {}
+
+    def assign_payment_id():
+        if captured_payment.get("payment") is not None:
+            captured_payment["payment"].id = "PAY_TEST01"
+
+    session.flush.side_effect = assign_payment_id
+
+    def capture_add(obj):
+        captured_payment["payment"] = obj
+
+    session.add.side_effect = capture_add
+
+    with patch("app.payments.services.session_scope") as mock_scope:
+        mock_scope.return_value.__enter__.return_value = session
+        with patch(
+            "app.payments.services.PaymentService.get_payment", return_value=payment
+        ):
+            with patch("app.payments.services.PaymentService._cache_payment"):
+                from app.orders.models import OrderStatus
+
+                order.status = OrderStatus.PENDING_PAYMENT
+                PaymentService.create_payment(
+                    order_id="ORD_TEST01",
+                    amount=None,
+                    method=PaymentMethod.WALLET,
+                )
+
+    mock_pay.assert_called_once()
+    mock_complete.assert_called_once_with(payment_id="PAY_TEST01")
+
+
+@patch.object(WalletService, "debit")
+def test_pay_for_order_uses_order_payment_reference(mock_debit):
+    WalletService.pay_for_order("USR_1", "ORD_1", "PAY_1", 1000.0)
+    mock_debit.assert_called_once()
+    assert mock_debit.call_args[0][2] == WalletReferenceType.ORDER_PAYMENT

--- a/tests/test_phase3_marketplace.py
+++ b/tests/test_phase3_marketplace.py
@@ -1,0 +1,159 @@
+"""Tests for Phase 3 marketplace payment features."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.libs.errors import ValidationError
+from app.orders.models import OrderReturnStatus, OrderStatus
+from app.orders.services import OrderService, RETURNABLE_ORDER_STATUSES
+from app.payments.services import PaymentService
+from app.wallet.models import TopUpStatus, WalletReferenceType
+from app.wallet.services import WalletService
+
+
+def test_returnable_order_statuses():
+    assert OrderStatus.SHIPPED in RETURNABLE_ORDER_STATUSES
+    assert OrderStatus.DELIVERED in RETURNABLE_ORDER_STATUSES
+    assert OrderStatus.PENDING_PAYMENT not in RETURNABLE_ORDER_STATUSES
+
+
+@patch("app.wallet.services.WalletService.credit")
+def test_approve_return_credits_buyer_wallet(mock_credit):
+    order = SimpleNamespace(
+        id="ORD_RET001",
+        total=8000.0,
+        buyer=SimpleNamespace(user_id="USR_BUYER1"),
+        items=[SimpleNamespace(seller_id=7, status=SimpleNamespace(value="delivered"))],
+        payments=[SimpleNamespace(status=SimpleNamespace(value="completed"))],
+    )
+    order_return = SimpleNamespace(
+        id="RET_TEST01",
+        status=OrderReturnStatus.REQUESTED,
+        refund_amount=8000.0,
+        order=order,
+        seller_notes=None,
+    )
+
+    session = MagicMock()
+    session.query.return_value.options.return_value.get.return_value = order_return
+
+    with patch("app.orders.services.session_scope") as mock_scope:
+        mock_scope.return_value.__enter__.return_value = session
+        from app.payments.models import PaymentStatus
+
+        for payment in order.payments:
+            payment.status = PaymentStatus.COMPLETED
+        from app.orders.models import OrderItem
+
+        order.items[0].status = OrderItem.Status.DELIVERED
+        OrderService.approve_return("RET_TEST01", seller_id=7)
+
+    mock_credit.assert_called_once()
+    assert mock_credit.call_args.kwargs["idempotency_key"] == "return-refund:RET_TEST01"
+
+
+@patch("app.wallet.services.WalletService.credit")
+def test_complete_topup_is_idempotent(mock_credit):
+    topup = SimpleNamespace(
+        id="TOP_ABC123",
+        user_id="USR_1",
+        amount=5000.0,
+        currency="NGN",
+        status=TopUpStatus.PENDING,
+    )
+
+    session = MagicMock()
+    session.query.return_value.get.return_value = topup
+
+    with patch("app.wallet.services.session_scope") as mock_scope:
+        mock_scope.return_value.__enter__.return_value = session
+        assert WalletService.complete_topup("TOP_TOP_ABC123") is True
+
+    mock_credit.assert_called_once()
+    assert mock_credit.call_args[0][2] == WalletReferenceType.WALLET_TOPUP
+
+
+@patch.object(WalletService, "credit")
+def test_settle_order_item_skips_when_paystack_split_used(mock_credit):
+    item = SimpleNamespace(
+        id=99,
+        order_id="ORD_SPLIT1",
+        price=1000.0,
+        quantity=1,
+        seller=SimpleNamespace(user_id="USR_SELLER"),
+    )
+    order = SimpleNamespace(paystack_split_used=True)
+
+    session = MagicMock()
+    session.query.return_value.get.return_value = order
+
+    with patch("app.wallet.services.session_scope") as mock_scope:
+        mock_scope.return_value.__enter__.return_value = session
+        result = WalletService.settle_order_item(item)
+
+    assert result is None
+    mock_credit.assert_not_called()
+
+
+@patch("app.payments.services.PaymentService.complete_payment")
+@patch("app.wallet.services.WalletService.complete_topup")
+def test_webhook_routes_topup_references(mock_topup, mock_complete):
+    mock_topup.return_value = True
+    data = {"reference": "TOP_123", "metadata": {"type": "wallet_topup"}}
+    assert PaymentService._handle_successful_charge(data) is True
+    mock_topup.assert_called_once()
+    mock_complete.assert_not_called()
+
+
+@patch("app.wallet.paystack_subaccounts.PaystackSubaccountClient.create_subaccount")
+def test_register_seller_payout_account(mock_create):
+    mock_create.return_value = {"subaccount_code": "ACCT_sub123"}
+    seller = SimpleNamespace(
+        id=5,
+        shop_name="Ada Shop",
+        paystack_subaccount_code=None,
+        payout_bank_code=None,
+        payout_account_number=None,
+        payout_account_name=None,
+    )
+
+    session = MagicMock()
+    session.query.return_value.get.return_value = seller
+
+    with patch("app.wallet.services.session_scope") as mock_scope:
+        mock_scope.return_value.__enter__.return_value = session
+        result = WalletService.register_seller_payout_account(
+            5,
+            bank_code="058",
+            account_number="0123456789",
+            account_name="Ada Lovelace",
+        )
+
+    assert result["subaccount_code"] == "ACCT_sub123"
+    mock_create.assert_called_once()
+
+
+def test_initialize_topup_rejects_small_amount():
+    with pytest.raises(ValidationError):
+        WalletService.initialize_topup("USR_1", 50.0)
+
+
+def test_resolve_subaccount_split_single_seller():
+    seller = SimpleNamespace(seller_id=1, paystack_subaccount_code="ACCT_abc")
+    item = SimpleNamespace(seller_id=1, seller=seller)
+    order = SimpleNamespace(items=[item])
+
+    split = PaymentService._resolve_subaccount_split(order)
+    assert split == {"subaccount_code": "ACCT_abc"}
+
+
+def test_resolve_subaccount_split_multi_seller_returns_none():
+    order = SimpleNamespace(
+        items=[
+            SimpleNamespace(seller_id=1, seller=None),
+            SimpleNamespace(seller_id=2, seller=None),
+        ]
+    )
+    assert PaymentService._resolve_subaccount_split(order) is None

--- a/tests/test_shipping.py
+++ b/tests/test_shipping.py
@@ -1,0 +1,80 @@
+"""Unit tests for shipping address normalization."""
+
+from unittest.mock import patch
+
+import pytest
+
+from app.libs.errors import ValidationError
+from app.orders.shipping import (
+    normalize_shipping_address,
+    shipping_address_to_model_kwargs,
+)
+
+
+def test_normalize_accepts_street_alias():
+    data = normalize_shipping_address(
+        {
+            "recipient_name": "Test User",
+            "street": "1 Market Road",
+            "city": "Lagos",
+            "state": "Lagos",
+            "postal_code": "100001",
+            "country": "Nigeria",
+            "latitude": 1.0,
+            "longitude": 2.0,
+        }
+    )
+    assert data["street_address"] == "1 Market Road"
+
+
+def test_normalize_rejects_empty_address():
+    with pytest.raises(ValidationError) as exc:
+        normalize_shipping_address({})
+    assert "shipping_address is required" in exc.value.message
+
+
+def test_normalize_rejects_missing_required_fields():
+    with pytest.raises(ValidationError) as exc:
+        normalize_shipping_address(
+            {
+                "street_address": "1 Road",
+                "city": "Lagos",
+                "state": "Lagos",
+                "postal_code": "100001",
+                "country": "Nigeria",
+            }
+        )
+    assert "recipient_name" in exc.value.message
+
+
+@patch("app.orders.shipping.geocode_address", return_value=(6.5, 3.4))
+def test_normalize_geocodes_when_coordinates_missing(mock_geocode):
+    data = normalize_shipping_address(
+        {
+            "recipient_name": "Test User",
+            "street_address": "1 Market Road",
+            "city": "Lagos",
+            "state": "Lagos",
+            "postal_code": "100001",
+            "country": "Nigeria",
+        }
+    )
+    mock_geocode.assert_called_once()
+    assert data["latitude"] == 6.5
+    assert data["longitude"] == 3.4
+
+
+def test_use_saved_address_merges_profile(sample_shipping_address):
+    data = normalize_shipping_address(
+        {"city": "Abuja"},
+        saved_address=sample_shipping_address,
+        use_saved_address=True,
+    )
+    assert data["city"] == "Abuja"
+    assert data["recipient_name"] == "Ada Lovelace"
+
+
+def test_shipping_address_to_model_kwargs(sample_shipping_address):
+    model_kwargs = shipping_address_to_model_kwargs(sample_shipping_address)
+    assert model_kwargs["street_address"] == "12 Broad Street"
+    assert model_kwargs["latitude"] == 6.45

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -13,6 +13,7 @@ from app.wallet.services import DEFAULT_COMMISSION_RATE, WalletService
 def test_settle_order_item_calculates_net_after_commission():
     item = SimpleNamespace(
         id=42,
+        order_id="ORD_1",
         price=10000.0,
         quantity=2,
         seller=SimpleNamespace(user_id="USR_SELLER1"),
@@ -20,11 +21,17 @@ def test_settle_order_item_calculates_net_after_commission():
     gross = item.price * item.quantity
     expected_net = round(gross * (1 - DEFAULT_COMMISSION_RATE), 2)
 
-    with patch.object(WalletService, "credit") as mock_credit:
-        mock_credit.return_value = MagicMock()
-        WalletService.settle_order_item(item)
-        mock_credit.assert_called_once()
-        assert mock_credit.call_args[0][1] == expected_net
+    order = SimpleNamespace(paystack_split_used=False)
+    session = MagicMock()
+    session.query.return_value.get.return_value = order
+
+    with patch("app.wallet.services.session_scope") as mock_scope:
+        mock_scope.return_value.__enter__.return_value = session
+        with patch.object(WalletService, "credit") as mock_credit:
+            mock_credit.return_value = MagicMock()
+            WalletService.settle_order_item(item)
+            mock_credit.assert_called_once()
+            assert mock_credit.call_args[0][1] == expected_net
 
 
 def test_credit_rejects_non_positive_amount():

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -1,0 +1,38 @@
+"""Unit tests for wallet service helpers."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.libs.errors import ValidationError
+from app.wallet.models import WalletReferenceType
+from app.wallet.services import DEFAULT_COMMISSION_RATE, WalletService
+
+
+def test_settle_order_item_calculates_net_after_commission():
+    item = SimpleNamespace(
+        id=42,
+        price=10000.0,
+        quantity=2,
+        seller=SimpleNamespace(user_id="USR_SELLER1"),
+    )
+    gross = item.price * item.quantity
+    expected_net = round(gross * (1 - DEFAULT_COMMISSION_RATE), 2)
+
+    with patch.object(WalletService, "credit") as mock_credit:
+        mock_credit.return_value = MagicMock()
+        WalletService.settle_order_item(item)
+        mock_credit.assert_called_once()
+        assert mock_credit.call_args[0][1] == expected_net
+
+
+def test_credit_rejects_non_positive_amount():
+    with pytest.raises(ValidationError) as exc:
+        WalletService.credit(
+            "USR_1",
+            0,
+            WalletReferenceType.ADJUSTMENT,
+            "ref-1",
+        )
+    assert "positive" in exc.value.message


### PR DESCRIPTION
## Description
Paystack's checkout callback was redirecting every user to a single hardcoded
`FRONTEND_BASE_URL` (defaulting to `http://localhost:3000`), which caused
`ERR_CONNECTION_REFUSED` for any client where that wasn't actually running
(e.g. a mobile webview). The callback now distinguishes mobile vs. web
clients and redirects accordingly:
- Mobile to `markt://payment/success` or `markt://payment/failed` (deep link)
- Web to `https://marktcommerce.com/app/payment-success` or `-failed`

The originating platform is passed by the client as `metadata.platform`
(`"mobile"` or `"web"`) on `POST /payments/initialize` (or `/create`), threaded
through the Paystack `callback_url` as a query param, and read back by
`PaymentCallback.get` to pick the redirect target. `FRONTEND_BASE_URL` is
replaced by `WEB_APP_BASE_URL` + `MOBILE_APP_SCHEME` in config.

## Tickets
Ticket ID [link]

## Related Issue
Fixes #[Issue number]

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?
[Attach the UNIT TEST coverage report]

Manually traced the request flow (initialize → Paystack → callback) and
verified the redirect URLs are built correctly for both `platform=mobile`
and `platform=web` against the new config defaults. No automated tests were
added — flagging this in case it's required before merge.

## Tested & Approved by?
[QA Engineer]

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
`FRONTEND_BASE_URL` was removed entirely (only consumer was this callback
route) in favor of `WEB_APP_BASE_URL` + `MOBILE_APP_SCHEME`. Mobile/web
clients calling `/payments/initialize` need to pass `metadata: {"platform":
"mobile"}` going forward — defaults to `"web"` if omitted, so existing web
clients are unaffected.

Separately noticed (not fixed in this PR): the Paystack `reference` is
double-prefixed (`PAY_PAY_XXXXXXXX`) because `payment.id` possibly already includes
the `PAY_` prefix before `services.py` prepends another one. Self-consistent,
just slightly off, worth a follow-up.
