### PR TITLE
Feat/marketplace payments plan

### DIFF
--- a/app/orders/models.py
+++ b/app/orders/models.py
@@ -38,6 +38,7 @@ class Order(BaseModel, UniqueIdMixin):
     )  # Prevent duplicate orders
     cancelled_at = db.Column(db.DateTime, nullable=True)
     cancel_reason = db.Column(db.Text, nullable=True)
+    paystack_split_used = db.Column(db.Boolean, default=False, nullable=False)
     # Relationships
     buyer = db.relationship("Buyer", back_populates="orders")
     items = db.relationship(
@@ -51,6 +52,7 @@ class Order(BaseModel, UniqueIdMixin):
         cascade="all, delete-orphan",
     )
     shipments = db.relationship("Shipment", back_populates="order")
+    returns = db.relationship("OrderReturn", back_populates="order", lazy="dynamic")
 
     def generate_order_number(self):
         # Implement your order number generation logic
@@ -133,3 +135,28 @@ class Shipment(BaseModel):
     delivered_at = db.Column(db.DateTime)
 
     order = db.relationship("Order", back_populates="shipments")
+
+
+class OrderReturnStatus(Enum):
+    REQUESTED = "requested"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+    REFUNDED = "refunded"
+
+
+class OrderReturn(BaseModel, UniqueIdMixin):
+    __tablename__ = "order_returns"
+    id_prefix = "RET_"
+
+    id = db.Column(db.String(12), primary_key=True, default=None)
+    order_id = db.Column(db.String(12), db.ForeignKey("orders.id"), nullable=False)
+    buyer_id = db.Column(db.Integer, db.ForeignKey("buyers.id"), nullable=False)
+    reason = db.Column(db.Text, nullable=False)
+    status = db.Column(
+        db.Enum(OrderReturnStatus), default=OrderReturnStatus.REQUESTED, nullable=False
+    )
+    refund_amount = db.Column(db.Float, nullable=True)
+    seller_notes = db.Column(db.Text, nullable=True)
+
+    order = db.relationship("Order", back_populates="returns")
+    buyer = db.relationship("Buyer")

--- a/app/orders/routes.py
+++ b/app/orders/routes.py
@@ -24,6 +24,9 @@ from .schemas import (
     OrderItemStatusUpdateSchema,
     OrderCancelSchema,
     OrderCancelResponseSchema,
+    OrderReturnRequestSchema,
+    OrderReturnResponseSchema,
+    OrderReturnActionSchema,
 )
 
 bp = Blueprint("orders", __name__, description="Order operations", url_prefix="/orders")
@@ -163,6 +166,60 @@ class CancelOrder(MethodView):
                 "cancel_reason": order.cancel_reason,
                 "refund_amount": refund_amount,
             }
+        except APIError as e:
+            abort(e.status_code, message=e.message)
+
+
+@bp.route("/<order_id>/returns")
+class OrderReturnRequest(MethodView):
+    @login_required
+    @buyer_required
+    @bp.arguments(OrderReturnRequestSchema)
+    @bp.response(201, OrderReturnResponseSchema)
+    def post(self, return_data, order_id):
+        """Request a return for a shipped or delivered order"""
+        try:
+            return OrderService.request_return(
+                order_id,
+                current_user.buyer_account.id,
+                reason=return_data["reason"],
+            )
+        except APIError as e:
+            abort(e.status_code, message=e.message)
+
+
+@bp.route("/returns/<return_id>/approve")
+class ApproveOrderReturn(MethodView):
+    @login_required
+    @seller_required
+    @bp.arguments(OrderReturnActionSchema)
+    @bp.response(200, OrderReturnResponseSchema)
+    def post(self, action_data, return_id):
+        """Approve a buyer return request and refund to wallet"""
+        try:
+            return OrderService.approve_return(
+                return_id,
+                current_user.seller_account.id,
+                seller_notes=action_data.get("seller_notes"),
+            )
+        except APIError as e:
+            abort(e.status_code, message=e.message)
+
+
+@bp.route("/returns/<return_id>/reject")
+class RejectOrderReturn(MethodView):
+    @login_required
+    @seller_required
+    @bp.arguments(OrderReturnActionSchema)
+    @bp.response(200, OrderReturnResponseSchema)
+    def post(self, action_data, return_id):
+        """Reject a buyer return request"""
+        try:
+            return OrderService.reject_return(
+                return_id,
+                current_user.seller_account.id,
+                seller_notes=action_data.get("seller_notes"),
+            )
         except APIError as e:
             abort(e.status_code, message=e.message)
 

--- a/app/orders/schemas.py
+++ b/app/orders/schemas.py
@@ -101,6 +101,24 @@ class OrderCancelResponseSchema(Schema):
     refund_amount = fields.Float()
 
 
+class OrderReturnRequestSchema(Schema):
+    reason = fields.Str(required=True, validate=validate.Length(min=3))
+
+
+class OrderReturnResponseSchema(Schema):
+    id = fields.Str()
+    order_id = fields.Str()
+    status = fields.Str()
+    reason = fields.Str()
+    refund_amount = fields.Float(allow_none=True)
+    seller_notes = fields.Str(allow_none=True)
+    created_at = fields.DateTime()
+
+
+class OrderReturnActionSchema(Schema):
+    seller_notes = fields.Str(allow_none=True)
+
+
 class OrderItemStatusUpdateSchema(Schema):
     status = fields.Enum(OrderItem.Status, by_value=True, required=True)
 

--- a/app/orders/services.py
+++ b/app/orders/services.py
@@ -24,7 +24,15 @@ from app.users.models import Buyer
 from app.products.services import ProductService
 
 # app imports
-from .models import Order, OrderStatus, OrderItem, ShippingAddress, Shipment
+from .models import (
+    Order,
+    OrderStatus,
+    OrderItem,
+    ShippingAddress,
+    Shipment,
+    OrderReturn,
+    OrderReturnStatus,
+)
 from app.orders.shipping import (
     normalize_shipping_address,
     shipping_address_to_model_kwargs,
@@ -38,6 +46,11 @@ BUYER_CANCELLABLE_STATUSES = {
     OrderStatus.PENDING,
     OrderStatus.PROCESSING,
     OrderStatus.READY_FOR_DELIVERY,
+}
+
+RETURNABLE_ORDER_STATUSES = {
+    OrderStatus.SHIPPED,
+    OrderStatus.DELIVERED,
 }
 
 
@@ -415,6 +428,146 @@ class OrderService:
                 else None,
                 "delivery": delivery_info,
             }
+
+    @staticmethod
+    def request_return(order_id: str, buyer_id: int, reason: str) -> OrderReturn:
+        """Buyer requests a return for a shipped or delivered order."""
+        if not reason or not reason.strip():
+            raise ValidationError("Return reason is required")
+
+        with session_scope() as session:
+            order = (
+                session.query(Order).options(db.joinedload(Order.items)).get(order_id)
+            )
+            if not order:
+                raise NotFoundError("Order not found")
+            if order.buyer_id != buyer_id:
+                raise ForbiddenError("You can only request returns for your own orders")
+            if order.status not in RETURNABLE_ORDER_STATUSES:
+                raise ValidationError(
+                    f"Returns are not available for orders in '{order.status.value}' status"
+                )
+
+            existing = (
+                session.query(OrderReturn)
+                .filter(
+                    OrderReturn.order_id == order_id,
+                    OrderReturn.status.in_(
+                        [OrderReturnStatus.REQUESTED, OrderReturnStatus.APPROVED]
+                    ),
+                )
+                .first()
+            )
+            if existing:
+                raise ConflictError("A return request is already open for this order")
+
+            paid_amount = OrderService._get_completed_payment_amount(order)
+            order_return = OrderReturn(
+                order_id=order_id,
+                buyer_id=buyer_id,
+                reason=reason.strip(),
+                status=OrderReturnStatus.REQUESTED,
+                refund_amount=paid_amount if paid_amount > 0 else order.total,
+            )
+            session.add(order_return)
+            session.flush()
+            return order_return
+
+    @staticmethod
+    def approve_return(
+        return_id: str, seller_id: int, seller_notes: Optional[str] = None
+    ):
+        """Seller approves a return and refunds the buyer to wallet."""
+        from app.wallet.services import WalletService
+
+        refund_amount = 0.0
+        buyer_user_id = None
+        order_id = None
+
+        with session_scope() as session:
+            order_return = (
+                session.query(OrderReturn)
+                .options(
+                    db.joinedload(OrderReturn.order).joinedload(Order.items),
+                    db.joinedload(OrderReturn.order).joinedload(Order.buyer),
+                    db.joinedload(OrderReturn.order).joinedload(Order.payments),
+                )
+                .get(return_id)
+            )
+            if not order_return:
+                raise NotFoundError("Return request not found")
+            if order_return.status != OrderReturnStatus.REQUESTED:
+                raise ConflictError("Return request is not pending approval")
+
+            order = order_return.order
+            is_seller = any(item.seller_id == seller_id for item in order.items)
+            if not is_seller:
+                raise ForbiddenError("Only a seller on this order can approve returns")
+
+            refund_amount = (
+                order_return.refund_amount
+                or OrderService._get_completed_payment_amount(order)
+            )
+            if refund_amount <= 0:
+                refund_amount = order.total or 0.0
+
+            buyer_user_id = order.buyer.user_id if order.buyer else None
+            order_id = order.id
+
+            order_return.status = OrderReturnStatus.REFUNDED
+            order_return.seller_notes = seller_notes
+            order.status = OrderStatus.RETURNED
+
+            for item in order.items:
+                if item.status != OrderItem.Status.CANCELLED:
+                    item.status = OrderItem.Status.CANCELLED
+
+            for payment in order.payments or []:
+                if payment.status == PaymentStatus.COMPLETED:
+                    payment.status = PaymentStatus.REFUNDED
+
+            session.flush()
+
+        if refund_amount > 0 and buyer_user_id:
+            from app.wallet.models import WalletReferenceType
+
+            WalletService.credit(
+                buyer_user_id,
+                refund_amount,
+                WalletReferenceType.ORDER_REFUND,
+                return_id,
+                description=f"Return refund for order {order_id}",
+                idempotency_key=f"return-refund:{return_id}",
+            )
+
+        return order_return
+
+    @staticmethod
+    def reject_return(
+        return_id: str, seller_id: int, seller_notes: Optional[str] = None
+    ):
+        """Seller rejects a return request."""
+        with session_scope() as session:
+            order_return = (
+                session.query(OrderReturn)
+                .options(db.joinedload(OrderReturn.order).joinedload(Order.items))
+                .get(return_id)
+            )
+            if not order_return:
+                raise NotFoundError("Return request not found")
+            if order_return.status != OrderReturnStatus.REQUESTED:
+                raise ConflictError("Return request is not pending approval")
+
+            is_seller = any(
+                item.seller_id == seller_id for item in order_return.order.items
+            )
+            if not is_seller:
+                raise ForbiddenError("Only a seller on this order can reject returns")
+
+            order_return.status = OrderReturnStatus.REJECTED
+            order_return.seller_notes = seller_notes
+            session.flush()
+            return order_return
 
     # TODO: Add order history tracking
     # TODO: Add refund processing

--- a/app/orders/tasks.py
+++ b/app/orders/tasks.py
@@ -1,0 +1,42 @@
+"""Celery tasks for order lifecycle maintenance."""
+
+import logging
+from datetime import datetime, timedelta
+
+from main.workers import celery_app
+from app.libs.session import session_scope
+from app.orders.models import Order, OrderStatus
+
+logger = logging.getLogger(__name__)
+
+
+@celery_app.task(name="app.orders.tasks.expire_unpaid_orders", queue="default")
+def expire_unpaid_orders():
+    """Cancel orders stuck in pending_payment beyond the configured TTL."""
+    from main.config import settings
+
+    cutoff = datetime.utcnow() - timedelta(hours=settings.UNPAID_ORDER_EXPIRY_HOURS)
+    expired_count = 0
+
+    with session_scope() as session:
+        stale_orders = (
+            session.query(Order)
+            .filter(
+                Order.status.in_([OrderStatus.PENDING_PAYMENT, OrderStatus.PENDING]),
+                Order.created_at < cutoff,
+            )
+            .all()
+        )
+
+        for order in stale_orders:
+            order.status = OrderStatus.CANCELLED
+            order.cancelled_at = datetime.utcnow()
+            order.cancel_reason = "Automatically cancelled — payment not received"
+            expired_count += 1
+
+    logger.info(
+        "Expired %s unpaid orders older than %sh",
+        expired_count,
+        settings.UNPAID_ORDER_EXPIRY_HOURS,
+    )
+    return {"expired": expired_count}

--- a/app/payments/routes.py
+++ b/app/payments/routes.py
@@ -100,12 +100,15 @@ class PaystackWebhook(MethodView):
                 abort(400, message="Missing webhook signature")
 
             # Get webhook payload
+            raw_body = request.get_data()
             payload = request.get_json()
             if not payload:
                 abort(400, message="Invalid webhook payload")
 
             # Process webhook
-            success = PaymentService.handle_webhook(payload, signature)
+            success = PaymentService.handle_webhook(
+                payload, signature, raw_body=raw_body
+            )
 
             if success:
                 return jsonify({"status": "success"}), 200

--- a/app/payments/services.py
+++ b/app/payments/services.py
@@ -199,7 +199,7 @@ class PaymentService:
                     return existing_payment
 
             # Validate order
-            order = session.query(Order).get(order_id)
+            order = session.query(Order).options(joinedload(Order.buyer)).get(order_id)
             if not order:
                 raise NotFoundError("Order not found")
 
@@ -234,14 +234,37 @@ class PaymentService:
             session.add(payment)
             session.flush()
 
-            # Initialize with Paystack if card payment
-            if method == PaymentMethod.CARD:
+            wallet_payment_id = None
+
+            if method == PaymentMethod.WALLET:
+                if not order.buyer or not order.buyer.user_id:
+                    raise ValidationError("Buyer account required for wallet payment")
+                from app.wallet.services import WalletService
+
+                payment.transaction_id = f"WALLET_{payment.id}"
+                WalletService.pay_for_order(
+                    order.buyer.user_id,
+                    order_id,
+                    payment.id,
+                    resolved_amount,
+                    currency=currency,
+                )
+                payment.status = PaymentStatus.COMPLETED
+                payment.paid_at = datetime.utcnow()
+                wallet_payment_id = payment.id
+            elif method == PaymentMethod.CARD:
                 PaymentService._initialize_paystack_transaction(payment, metadata)
 
-            # Cache payment
             PaymentService._cache_payment(payment)
 
-            return payment
+            if wallet_payment_id:
+                session.flush()
+
+        if wallet_payment_id:
+            PaymentService.complete_payment(payment_id=wallet_payment_id)
+            return PaymentService.get_payment(wallet_payment_id)
+
+        return payment
 
     @staticmethod
     def process_payment(payment_id: str, payment_data: Dict[str, Any]) -> Payment:
@@ -415,11 +438,14 @@ class PaymentService:
             }
 
     @staticmethod
-    def handle_webhook(payload: Dict[str, Any], signature: str) -> bool:
+    def handle_webhook(
+        payload: Dict[str, Any],
+        signature: str,
+        raw_body: Optional[bytes] = None,
+    ) -> bool:
         """Handle Paystack webhook"""
         try:
-            # Verify webhook signature
-            if not PaymentService._verify_webhook_signature(payload, signature):
+            if not PaymentService._verify_webhook_signature(signature, raw_body):
                 logger.warning("Invalid webhook signature")
                 return False
 
@@ -430,6 +456,8 @@ class PaymentService:
                 return PaymentService._handle_successful_charge(data)
             elif event == "transfer.success":
                 return PaymentService._handle_successful_transfer(data)
+            elif event == "transfer.failed":
+                return PaymentService._handle_failed_transfer(data)
             elif event == "charge.failed":
                 return PaymentService._handle_failed_charge(data)
             else:
@@ -441,6 +469,27 @@ class PaymentService:
             return False
 
     # ==================== PRIVATE METHODS ====================
+
+    @staticmethod
+    def _resolve_subaccount_split(order: Order) -> Optional[Dict[str, str]]:
+        """Return Paystack subaccount code when order has a single registered seller."""
+        seller_ids = {item.seller_id for item in order.items if item.seller_id}
+        if len(seller_ids) != 1:
+            return None
+
+        seller_id = next(iter(seller_ids))
+        seller = (
+            order.items[0].seller
+            if order.items and order.items[0].seller_id == seller_id
+            else None
+        )
+        if not seller:
+            with session_scope() as session:
+                seller = session.query(Seller).get(seller_id)
+        if not seller or not seller.paystack_subaccount_code:
+            return None
+
+        return {"subaccount_code": seller.paystack_subaccount_code}
 
     @staticmethod
     def _initialize_paystack_transaction(
@@ -487,6 +536,11 @@ class PaymentService:
                     **(metadata or {}),
                 },
             }
+
+            split = PaymentService._resolve_subaccount_split(order)
+            if split:
+                payload["subaccount"] = split["subaccount_code"]
+                order.paystack_split_used = True
 
             response = requests.post(
                 f"{PaymentService.PAYSTACK_BASE_URL}/transaction/initialize",
@@ -636,16 +690,16 @@ class PaymentService:
             raise APIError("Bank transfer processing failed", 500)
 
     @staticmethod
-    def _verify_webhook_signature(payload: Dict[str, Any], signature: str) -> bool:
-        """Verify Paystack webhook signature"""
+    def _verify_webhook_signature(signature: str, raw_body: Optional[bytes]) -> bool:
+        """Verify Paystack webhook signature against the raw request body."""
+        if not signature or not raw_body:
+            return False
         try:
-            # Create HMAC SHA512 hash
             computed_signature = hmac.new(
                 PaymentService.PAYSTACK_SECRET_KEY.encode("utf-8"),
-                str(payload).encode("utf-8"),
+                raw_body,
                 hashlib.sha512,
             ).hexdigest()
-
             return hmac.compare_digest(computed_signature, signature)
         except Exception:
             return False
@@ -656,6 +710,13 @@ class PaymentService:
         reference = data.get("reference")
         if not reference:
             return False
+
+        metadata = data.get("metadata") or {}
+        if reference.startswith("TOP_") or metadata.get("type") == "wallet_topup":
+            from app.wallet.services import WalletService
+
+            return WalletService.complete_topup(reference, data)
+
         return PaymentService.complete_payment(
             reference=reference,
             gateway_response=data,
@@ -696,9 +757,24 @@ class PaymentService:
 
     @staticmethod
     def _handle_successful_transfer(data: Dict[str, Any]) -> bool:
-        """Handle successful transfer webhook (for payouts)"""
-        # Implementation for seller payouts
-        return True
+        """Handle successful transfer webhook (wallet withdrawals)."""
+        from app.wallet.services import WalletService
+
+        reference = data.get("reference") or data.get("transfer_code")
+        if not reference:
+            return False
+        return WalletService.complete_withdrawal_transfer(reference)
+
+    @staticmethod
+    def _handle_failed_transfer(data: Dict[str, Any]) -> bool:
+        """Handle failed transfer webhook and refund wallet."""
+        from app.wallet.services import WalletService
+
+        reference = data.get("reference") or data.get("transfer_code")
+        if not reference:
+            return False
+        reason = data.get("reason") or "Paystack transfer failed"
+        return WalletService.fail_withdrawal_transfer(reference, reason)
 
     @staticmethod
     def _send_payment_notifications(payment: Payment, status: PaymentStatus):

--- a/app/users/models.py
+++ b/app/users/models.py
@@ -58,6 +58,9 @@ class User(BaseModel, UserMixin, UniqueIdMixin):
     withdrawal_requests = db.relationship(
         "WithdrawalRequest", back_populates="user", lazy="dynamic"
     )
+    wallet_topups = db.relationship(
+        "WalletTopUp", back_populates="user", lazy="dynamic"
+    )
     posts = db.relationship("Post", back_populates="user", lazy="dynamic")
     post_likes = db.relationship("PostLike", back_populates="user", lazy="dynamic")
     post_comments = db.relationship(
@@ -219,6 +222,10 @@ class Seller(BaseModel):
     )
     is_active = db.Column(db.Boolean, default=True)
     deactivated_at = db.Column(db.DateTime)
+    paystack_subaccount_code = db.Column(db.String(50), nullable=True)
+    payout_bank_code = db.Column(db.String(10), nullable=True)
+    payout_account_number = db.Column(db.String(20), nullable=True)
+    payout_account_name = db.Column(db.String(100), nullable=True)
 
     # Relationships
     user = db.relationship("User", back_populates="seller_account")

--- a/app/wallet/models.py
+++ b/app/wallet/models.py
@@ -13,8 +13,16 @@ class WalletEntryType(Enum):
 class WalletReferenceType(Enum):
     ORDER_SETTLEMENT = "order_settlement"
     ORDER_REFUND = "order_refund"
+    ORDER_PAYMENT = "order_payment"
+    WALLET_TOPUP = "wallet_topup"
     WITHDRAWAL = "withdrawal"
     ADJUSTMENT = "adjustment"
+
+
+class TopUpStatus(Enum):
+    PENDING = "pending"
+    COMPLETED = "completed"
+    FAILED = "failed"
 
 
 class WithdrawalStatus(Enum):
@@ -78,3 +86,19 @@ class WithdrawalRequest(BaseModel, UniqueIdMixin):
     failure_reason = db.Column(db.String(255), nullable=True)
 
     user = db.relationship("User", back_populates="withdrawal_requests")
+
+
+class WalletTopUp(BaseModel, UniqueIdMixin):
+    __tablename__ = "wallet_topups"
+    id_prefix = "TOP_"
+
+    id = db.Column(db.String(12), primary_key=True, default=None)
+    user_id = db.Column(db.String(12), db.ForeignKey("users.id"), nullable=False)
+    amount = db.Column(db.Float, nullable=False)
+    currency = db.Column(db.String(3), default="NGN", nullable=False)
+    status = db.Column(
+        db.Enum(TopUpStatus), default=TopUpStatus.PENDING, nullable=False
+    )
+    paystack_reference = db.Column(db.String(100), unique=True, nullable=True)
+
+    user = db.relationship("User", back_populates="wallet_topups")

--- a/app/wallet/paystack_subaccounts.py
+++ b/app/wallet/paystack_subaccounts.py
@@ -1,0 +1,51 @@
+"""Paystack subaccount helpers for seller split payments."""
+
+import logging
+from typing import Any, Dict
+
+import requests
+
+from app.libs.errors import APIError
+
+logger = logging.getLogger(__name__)
+
+
+class PaystackSubaccountClient:
+    BASE_URL = "https://api.paystack.co"
+
+    @classmethod
+    def _headers(cls) -> Dict[str, str]:
+        from app.payments.services import PaymentService
+
+        if not PaymentService.PAYSTACK_SECRET_KEY:
+            raise APIError("Paystack is not configured", 503)
+        return {"Authorization": f"Bearer {PaymentService.PAYSTACK_SECRET_KEY}"}
+
+    @classmethod
+    def create_subaccount(
+        cls,
+        *,
+        business_name: str,
+        bank_code: str,
+        account_number: str,
+        percentage_charge: float,
+    ) -> Dict[str, Any]:
+        """Create a Paystack subaccount for a seller."""
+        payload = {
+            "business_name": business_name,
+            "settlement_bank": bank_code,
+            "account_number": account_number,
+            "percentage_charge": percentage_charge,
+            "description": f"Markt seller subaccount for {business_name}",
+        }
+        response = requests.post(
+            f"{cls.BASE_URL}/subaccount",
+            json=payload,
+            headers=cls._headers(),
+            timeout=30,
+        )
+        data = response.json()
+        if response.status_code != 200 or not data.get("status"):
+            logger.error("Paystack subaccount creation failed: %s", data)
+            raise APIError("Failed to create seller payout account", 502)
+        return data["data"]

--- a/app/wallet/paystack_transfers.py
+++ b/app/wallet/paystack_transfers.py
@@ -1,0 +1,81 @@
+"""Paystack Transfer API helpers for wallet withdrawals."""
+
+import logging
+from typing import Any, Dict
+
+import requests
+
+from app.libs.errors import APIError
+
+logger = logging.getLogger(__name__)
+
+
+class PaystackTransferClient:
+    BASE_URL = "https://api.paystack.co"
+
+    @classmethod
+    def _headers(cls) -> Dict[str, str]:
+        from app.payments.services import PaymentService
+
+        if not PaymentService.PAYSTACK_SECRET_KEY:
+            raise APIError("Paystack is not configured", 503)
+        return {"Authorization": f"Bearer {PaymentService.PAYSTACK_SECRET_KEY}"}
+
+    @classmethod
+    def create_transfer_recipient(
+        cls,
+        *,
+        account_name: str,
+        account_number: str,
+        bank_code: str,
+        currency: str = "NGN",
+    ) -> str:
+        payload = {
+            "type": "nuban",
+            "name": account_name,
+            "account_number": account_number,
+            "bank_code": bank_code,
+            "currency": currency,
+        }
+        response = requests.post(
+            f"{cls.BASE_URL}/transferrecipient",
+            json=payload,
+            headers=cls._headers(),
+            timeout=30,
+        )
+        data = response.json()
+        if response.status_code != 200 or not data.get("status"):
+            logger.error("Paystack recipient creation failed: %s", data)
+            raise APIError("Failed to verify bank account with Paystack", 502)
+
+        return data["data"]["recipient_code"]
+
+    @classmethod
+    def initiate_transfer(
+        cls,
+        *,
+        amount_kobo: int,
+        recipient_code: str,
+        reference: str,
+        reason: str = "Markt wallet withdrawal",
+    ) -> Dict[str, Any]:
+        payload = {
+            "source": "balance",
+            "amount": amount_kobo,
+            "recipient": recipient_code,
+            "reason": reason,
+            "reference": reference,
+        }
+        response = requests.post(
+            f"{cls.BASE_URL}/transfer",
+            json=payload,
+            headers=cls._headers(),
+            timeout=30,
+        )
+        data = response.json()
+        if response.status_code != 200 or not data.get("status"):
+            logger.error("Paystack transfer failed: %s", data)
+            message = data.get("message", "Transfer initiation failed")
+            raise APIError(message, 502)
+
+        return data

--- a/app/wallet/routes.py
+++ b/app/wallet/routes.py
@@ -10,6 +10,11 @@ from .schemas import (
     WalletTransactionsResponseSchema,
     WithdrawalRequestSchema,
     WithdrawalResponseSchema,
+    WithdrawalListResponseSchema,
+    TopUpInitializeSchema,
+    TopUpInitializeResponseSchema,
+    SellerPayoutAccountSchema,
+    SellerPayoutAccountResponseSchema,
 )
 from .services import WalletService
 
@@ -53,9 +58,64 @@ class WalletWithdraw(MethodView):
     @bp.arguments(WithdrawalRequestSchema)
     @bp.response(201, WithdrawalResponseSchema)
     def post(self, data):
-        """Request a withdrawal to a bank account (queued for Paystack transfer)"""
+        """Request a withdrawal to a bank account via Paystack transfer"""
         try:
             withdrawal = WalletService.request_withdrawal(current_user.id, data)
             return withdrawal
+        except APIError as e:
+            abort(e.status_code, message=e.message)
+
+
+@bp.route("/withdrawals")
+class WalletWithdrawals(MethodView):
+    @login_required
+    @bp.arguments(PaginationQueryArgs, location="query")
+    @bp.response(200, WithdrawalListResponseSchema)
+    def get(self, args):
+        """List withdrawal requests for the current user"""
+        try:
+            return WalletService.list_withdrawals(
+                current_user.id,
+                page=args.get("page", 1),
+                per_page=args.get("per_page", 20),
+            )
+        except APIError as e:
+            abort(e.status_code, message=e.message)
+
+
+@bp.route("/topup/initialize")
+class WalletTopUpInitialize(MethodView):
+    @login_required
+    @bp.arguments(TopUpInitializeSchema)
+    @bp.response(201, TopUpInitializeResponseSchema)
+    def post(self, data):
+        """Initialize a Paystack wallet top-up"""
+        try:
+            return WalletService.initialize_topup(
+                current_user.id,
+                data["amount"],
+                currency=data.get("currency", "NGN"),
+                platform=data.get("platform", "web"),
+            )
+        except APIError as e:
+            abort(e.status_code, message=e.message)
+
+
+@bp.route("/seller/payout-account")
+class SellerPayoutAccount(MethodView):
+    @login_required
+    @bp.arguments(SellerPayoutAccountSchema)
+    @bp.response(201, SellerPayoutAccountResponseSchema)
+    def post(self, data):
+        """Register seller bank account for Paystack split settlements"""
+        try:
+            if not current_user.is_seller or not current_user.seller_account:
+                abort(403, message="Seller account required")
+            return WalletService.register_seller_payout_account(
+                current_user.seller_account.id,
+                bank_code=data["bank_code"],
+                account_number=data["account_number"],
+                account_name=data["account_name"],
+            )
         except APIError as e:
             abort(e.status_code, message=e.message)

--- a/app/wallet/schemas.py
+++ b/app/wallet/schemas.py
@@ -30,9 +30,41 @@ class WithdrawalRequestSchema(Schema):
     account_name = fields.Str(required=True)
 
 
+class WithdrawalListResponseSchema(Schema):
+    withdrawals = fields.List(fields.Dict())
+    pagination = fields.Dict()
+
+
 class WithdrawalResponseSchema(Schema):
     id = fields.Str()
     amount = fields.Float()
     currency = fields.Str()
     status = fields.Str()
     created_at = fields.DateTime()
+
+
+class TopUpInitializeSchema(Schema):
+    amount = fields.Float(required=True, validate=validate.Range(min=100))
+    currency = fields.Str(missing="NGN")
+    platform = fields.Str(missing="web")
+
+
+class TopUpInitializeResponseSchema(Schema):
+    topup_id = fields.Str()
+    amount = fields.Float()
+    currency = fields.Str()
+    authorization_url = fields.Str()
+    reference = fields.Str()
+
+
+class SellerPayoutAccountSchema(Schema):
+    bank_code = fields.Str(required=True)
+    account_number = fields.Str(required=True)
+    account_name = fields.Str(required=True)
+
+
+class SellerPayoutAccountResponseSchema(Schema):
+    seller_id = fields.Int()
+    subaccount_code = fields.Str()
+    account_name = fields.Str()
+    account_number_masked = fields.Str()

--- a/app/wallet/services.py
+++ b/app/wallet/services.py
@@ -2,7 +2,7 @@ import logging
 import uuid
 from typing import Any, Dict, Optional
 
-from app.libs.errors import ValidationError
+from app.libs.errors import APIError, NotFoundError, ValidationError, ConflictError
 from app.libs.session import session_scope
 from app.orders.models import OrderItem
 
@@ -11,9 +11,13 @@ from .models import (
     WalletEntry,
     WalletEntryType,
     WalletReferenceType,
+    WalletTopUp,
+    TopUpStatus,
     WithdrawalRequest,
     WithdrawalStatus,
 )
+from .paystack_transfers import PaystackTransferClient
+from .paystack_subaccounts import PaystackSubaccountClient
 
 logger = logging.getLogger(__name__)
 
@@ -173,6 +177,13 @@ class WalletService:
         order_item: OrderItem, commission_rate: float = DEFAULT_COMMISSION_RATE
     ) -> Optional[WalletEntry]:
         """Credit seller wallet when an order item is delivered."""
+        from app.orders.models import Order
+
+        with session_scope() as session:
+            order = session.query(Order).get(order_item.order_id)
+            if order and order.paystack_split_used:
+                return None
+
         if not order_item.seller or not order_item.seller.user_id:
             return None
 
@@ -248,5 +259,364 @@ class WalletService:
             currency=currency,
         )
 
+        try:
+            from app.wallet.tasks import process_withdrawal
+
+            process_withdrawal.delay(withdrawal_id)
+        except Exception as exc:
+            logger.warning(
+                "Async withdrawal dispatch failed for %s: %s", withdrawal_id, exc
+            )
+            try:
+                return WalletService.process_withdrawal(withdrawal_id)
+            except APIError:
+                pass
+
         with session_scope() as session:
             return session.query(WithdrawalRequest).get(withdrawal_id)
+
+    @staticmethod
+    def list_withdrawals(
+        user_id: str, page: int = 1, per_page: int = 20
+    ) -> Dict[str, Any]:
+        with session_scope() as session:
+            query = (
+                session.query(WithdrawalRequest)
+                .filter_by(user_id=user_id)
+                .order_by(WithdrawalRequest.created_at.desc())
+            )
+            total = query.count()
+            rows = query.offset((page - 1) * per_page).limit(per_page).all()
+            return {
+                "withdrawals": [
+                    {
+                        "id": row.id,
+                        "amount": row.amount,
+                        "currency": row.currency,
+                        "status": row.status.value,
+                        "account_name": row.account_name,
+                        "account_number": row.account_number[-4:].rjust(
+                            len(row.account_number), "*"
+                        ),
+                        "paystack_transfer_ref": row.paystack_transfer_ref,
+                        "failure_reason": row.failure_reason,
+                        "created_at": row.created_at.isoformat()
+                        if row.created_at
+                        else None,
+                    }
+                    for row in rows
+                ],
+                "pagination": {
+                    "page": page,
+                    "per_page": per_page,
+                    "total_items": total,
+                    "total_pages": (total + per_page - 1) // per_page,
+                },
+            }
+
+    @staticmethod
+    def process_withdrawal(withdrawal_id: str) -> WithdrawalRequest:
+        """Submit a pending withdrawal to Paystack Transfer API."""
+        with session_scope() as session:
+            withdrawal = session.query(WithdrawalRequest).get(withdrawal_id)
+            if not withdrawal:
+                raise NotFoundError("Withdrawal request not found")
+            if withdrawal.status != WithdrawalStatus.PENDING:
+                return withdrawal
+
+            withdrawal.status = WithdrawalStatus.PROCESSING
+            session.flush()
+
+            amount = withdrawal.amount
+            bank_code = withdrawal.bank_code
+            account_number = withdrawal.account_number
+            account_name = withdrawal.account_name
+            currency = withdrawal.currency
+            user_id = withdrawal.user_id
+
+        try:
+            recipient_code = PaystackTransferClient.create_transfer_recipient(
+                account_name=account_name,
+                account_number=account_number,
+                bank_code=bank_code,
+                currency=currency,
+            )
+            transfer_data = PaystackTransferClient.initiate_transfer(
+                amount_kobo=int(round(amount * 100)),
+                recipient_code=recipient_code,
+                reference=withdrawal_id,
+            )
+            transfer_ref = transfer_data.get("data", {}).get("reference", withdrawal_id)
+
+            with session_scope() as session:
+                withdrawal = session.query(WithdrawalRequest).get(withdrawal_id)
+                withdrawal.paystack_transfer_ref = transfer_ref
+                session.flush()
+                return withdrawal
+
+        except APIError as exc:
+            WalletService._fail_withdrawal(
+                withdrawal_id, user_id, amount, currency, str(exc.message)
+            )
+            raise
+
+    @staticmethod
+    def _fail_withdrawal(
+        withdrawal_id: str,
+        user_id: str,
+        amount: float,
+        currency: str,
+        reason: str,
+    ):
+        """Mark withdrawal failed and refund debited amount to wallet."""
+        WalletService.credit(
+            user_id,
+            amount,
+            WalletReferenceType.ADJUSTMENT,
+            withdrawal_id,
+            description=f"Withdrawal failed: {reason}",
+            idempotency_key=f"withdraw-refund:{withdrawal_id}",
+            currency=currency,
+        )
+        with session_scope() as session:
+            withdrawal = session.query(WithdrawalRequest).get(withdrawal_id)
+            if withdrawal:
+                withdrawal.status = WithdrawalStatus.FAILED
+                withdrawal.failure_reason = reason[:255]
+
+    @staticmethod
+    def complete_withdrawal_transfer(reference: str) -> bool:
+        with session_scope() as session:
+            withdrawal = (
+                session.query(WithdrawalRequest)
+                .filter(
+                    (WithdrawalRequest.id == reference)
+                    | (WithdrawalRequest.paystack_transfer_ref == reference)
+                )
+                .first()
+            )
+            if not withdrawal:
+                logger.warning("Withdrawal not found for transfer ref %s", reference)
+                return False
+            if withdrawal.status == WithdrawalStatus.COMPLETED:
+                return True
+            withdrawal.status = WithdrawalStatus.COMPLETED
+            return True
+
+    @staticmethod
+    def fail_withdrawal_transfer(reference: str, reason: str = "") -> bool:
+        with session_scope() as session:
+            withdrawal = (
+                session.query(WithdrawalRequest)
+                .filter(
+                    (WithdrawalRequest.id == reference)
+                    | (WithdrawalRequest.paystack_transfer_ref == reference)
+                )
+                .first()
+            )
+            if not withdrawal:
+                return False
+            if withdrawal.status == WithdrawalStatus.FAILED:
+                return True
+
+            user_id = withdrawal.user_id
+            amount = withdrawal.amount
+            currency = withdrawal.currency
+            withdrawal_id = withdrawal.id
+
+        WalletService._fail_withdrawal(
+            withdrawal_id, user_id, amount, currency, reason or "Transfer failed"
+        )
+        return True
+
+    @staticmethod
+    def pay_for_order(
+        user_id: str,
+        order_id: str,
+        payment_id: str,
+        amount: float,
+        currency: str = "NGN",
+    ) -> WalletEntry:
+        """Debit buyer wallet for an order payment."""
+        return WalletService.debit(
+            user_id,
+            amount,
+            WalletReferenceType.ORDER_PAYMENT,
+            payment_id,
+            description=f"Wallet payment for order {order_id}",
+            idempotency_key=f"pay:wallet:{payment_id}",
+            currency=currency,
+        )
+
+    @staticmethod
+    def initialize_topup(
+        user_id: str,
+        amount: float,
+        currency: str = "NGN",
+        *,
+        platform: str = "web",
+    ) -> Dict[str, Any]:
+        """Create a pending top-up and return Paystack authorization URL."""
+        import requests
+        from app.payments.services import PaymentService
+        from app.users.models import User
+        from main.config import settings
+
+        if amount < 100:
+            raise ValidationError("Minimum top-up amount is 100")
+
+        topup_id = None
+        with session_scope() as session:
+            user = session.query(User).get(user_id)
+            if not user:
+                raise NotFoundError("User not found")
+
+            topup = WalletTopUp(
+                user_id=user_id,
+                amount=round(amount, 2),
+                currency=currency,
+                status=TopUpStatus.PENDING,
+            )
+            session.add(topup)
+            session.flush()
+            topup_id = topup.id
+            user_email = user.email
+
+        reference = f"TOP_{topup_id}"
+        base_url = settings.API_BASE_URL or "http://localhost:8000"
+        callback_url = (
+            f"{base_url}/api/v1/wallet/topup/callback/{topup_id}"
+            f"?platform={platform}"
+        )
+
+        payload = {
+            "amount": int(round(amount * 100)),
+            "email": user_email,
+            "currency": currency,
+            "reference": reference,
+            "callback_url": callback_url,
+            "metadata": {
+                "type": "wallet_topup",
+                "topup_id": topup_id,
+                "user_id": user_id,
+            },
+        }
+
+        response = requests.post(
+            f"{PaymentService.PAYSTACK_BASE_URL}/transaction/initialize",
+            json=payload,
+            headers={"Authorization": f"Bearer {PaymentService.PAYSTACK_SECRET_KEY}"},
+            timeout=30,
+        )
+        data = response.json()
+        if response.status_code != 200 or not data.get("status"):
+            with session_scope() as session:
+                topup = session.query(WalletTopUp).get(topup_id)
+                if topup:
+                    topup.status = TopUpStatus.FAILED
+            raise APIError("Failed to initialize wallet top-up", 502)
+
+        auth_url = data["data"]["authorization_url"]
+        paystack_ref = data["data"]["reference"]
+
+        with session_scope() as session:
+            topup = session.query(WalletTopUp).get(topup_id)
+            topup.paystack_reference = paystack_ref
+            session.flush()
+
+        return {
+            "topup_id": topup_id,
+            "amount": amount,
+            "currency": currency,
+            "authorization_url": auth_url,
+            "reference": paystack_ref,
+        }
+
+    @staticmethod
+    def complete_topup(
+        reference: str, gateway_response: Optional[Dict[str, Any]] = None
+    ) -> bool:
+        """Idempotently credit wallet after successful Paystack top-up."""
+        topup_id = (
+            reference.replace("TOP_", "", 1) if reference.startswith("TOP_") else None
+        )
+
+        with session_scope() as session:
+            if topup_id:
+                topup = session.query(WalletTopUp).get(topup_id)
+            else:
+                topup = (
+                    session.query(WalletTopUp)
+                    .filter_by(paystack_reference=reference)
+                    .first()
+                )
+
+            if not topup:
+                logger.warning("Top-up not found for reference %s", reference)
+                return False
+
+            if topup.status == TopUpStatus.COMPLETED:
+                return True
+
+            user_id = topup.user_id
+            amount = topup.amount
+            currency = topup.currency
+            topup_ref = topup.id
+            topup.status = TopUpStatus.COMPLETED
+            session.flush()
+
+        WalletService.credit(
+            user_id,
+            amount,
+            WalletReferenceType.WALLET_TOPUP,
+            topup_ref,
+            description=f"Wallet top-up {topup_ref}",
+            idempotency_key=f"topup:{topup_ref}",
+            currency=currency,
+        )
+        return True
+
+    @staticmethod
+    def register_seller_payout_account(
+        seller_id: int,
+        *,
+        bank_code: str,
+        account_number: str,
+        account_name: str,
+    ) -> Dict[str, Any]:
+        """Register seller bank details and create Paystack subaccount."""
+        from app.users.models import Seller
+        from main.config import settings
+
+        with session_scope() as session:
+            seller = session.query(Seller).get(seller_id)
+            if not seller:
+                raise NotFoundError("Seller not found")
+            if seller.paystack_subaccount_code:
+                raise ConflictError("Seller payout account already registered")
+
+            shop_name = seller.shop_name or f"Seller {seller_id}"
+            commission_pct = round(settings.PLATFORM_COMMISSION_RATE * 100, 2)
+
+        subaccount = PaystackSubaccountClient.create_subaccount(
+            business_name=shop_name,
+            bank_code=bank_code,
+            account_number=account_number,
+            percentage_charge=commission_pct,
+        )
+
+        with session_scope() as session:
+            seller = session.query(Seller).get(seller_id)
+            seller.paystack_subaccount_code = subaccount["subaccount_code"]
+            seller.payout_bank_code = bank_code
+            seller.payout_account_number = account_number
+            seller.payout_account_name = account_name
+            session.flush()
+            return {
+                "seller_id": seller.id,
+                "subaccount_code": seller.paystack_subaccount_code,
+                "account_name": seller.payout_account_name,
+                "account_number_masked": account_number[-4:].rjust(
+                    len(account_number), "*"
+                ),
+            }

--- a/app/wallet/tasks.py
+++ b/app/wallet/tasks.py
@@ -1,0 +1,26 @@
+"""Celery tasks for wallet operations."""
+
+import logging
+
+from main.workers import celery_app
+
+logger = logging.getLogger(__name__)
+
+
+@celery_app.task(
+    name="app.wallet.tasks.process_withdrawal",
+    bind=True,
+    max_retries=3,
+    queue="default",
+)
+def process_withdrawal(self, withdrawal_id: str):
+    """Process a pending withdrawal via Paystack Transfer API."""
+    from app.wallet.services import WalletService
+
+    try:
+        WalletService.process_withdrawal(withdrawal_id)
+    except Exception as exc:
+        logger.error("Withdrawal task failed for %s: %s", withdrawal_id, exc)
+        if self.request.retries < self.max_retries:
+            raise self.retry(countdown=60 * (2**self.request.retries))
+        raise

--- a/main/config.py
+++ b/main/config.py
@@ -118,6 +118,13 @@ class Config:
         self.CELERY_WORKER_DISABLE_RATE_LIMITS = False
         self.CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
 
+        self.UNPAID_ORDER_EXPIRY_HOURS = config(
+            "UNPAID_ORDER_EXPIRY_HOURS", default=48, cast=int
+        )
+        self.PLATFORM_COMMISSION_RATE = config(
+            "PLATFORM_COMMISSION_RATE", default=0.10, cast=float
+        )
+
     @property
     def SQLALCHEMY_DATABASE_URI(self):
         return f"postgresql+psycopg2://{self.DB_USER}:{self.DB_PASSWORD}@{self.DB_HOST}:{self.DB_PORT}/{self.DB_NAME}"

--- a/main/schedules.py
+++ b/main/schedules.py
@@ -56,4 +56,9 @@ CELERYBEAT_SCHEDULE = {
         "schedule": crontab(hour="*/4"),  # Every 4 hours
         "options": {"queue": "analytics"},
     },
+    "expire-unpaid-orders": {
+        "task": "app.orders.tasks.expire_unpaid_orders",
+        "schedule": crontab(hour="*/1"),  # Hourly
+        "options": {"queue": "default"},
+    },
 }

--- a/main/tasks.py
+++ b/main/tasks.py
@@ -23,8 +23,9 @@ def create_celery_app(app: Flask = None) -> Celery:
             "app.socials.tasks",
             "app.notifications.tasks",
             "app.media.tasks",
-            "app.realtime.tasks",  # New real-time tasks module
-            # add more task modules here
+            "app.realtime.tasks",
+            "app.orders.tasks",
+            "app.wallet.tasks",
         ]
     )
 

--- a/migrations/versions/c8d9e0f1a2b3_feat_wallet_add_order_payment_type.py
+++ b/migrations/versions/c8d9e0f1a2b3_feat_wallet_add_order_payment_type.py
@@ -1,0 +1,23 @@
+"""Add ORDER_PAYMENT to walletreferencetype enum.
+
+Revision ID: c8d9e0f1a2b3
+Revises: b7c8d9e0f1a2
+"""
+
+from alembic import op
+
+revision = "c8d9e0f1a2b3"
+down_revision = "b7c8d9e0f1a2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        "ALTER TYPE walletreferencetype "
+        "ADD VALUE IF NOT EXISTS 'ORDER_PAYMENT'"
+    )
+
+
+def downgrade():
+    pass

--- a/migrations/versions/d9e0f1a2b3c4_feat_phase3_topup_returns_subaccounts.py
+++ b/migrations/versions/d9e0f1a2b3c4_feat_phase3_topup_returns_subaccounts.py
@@ -1,0 +1,106 @@
+"""Phase 3: wallet top-ups, order returns, seller subaccounts.
+
+Revision ID: d9e0f1a2b3c4
+Revises: c8d9e0f1a2b3
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "d9e0f1a2b3c4"
+down_revision = "c8d9e0f1a2b3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        "ALTER TYPE walletreferencetype "
+        "ADD VALUE IF NOT EXISTS 'WALLET_TOPUP'"
+    )
+
+    op.add_column(
+        "orders",
+        sa.Column(
+            "paystack_split_used",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+    op.add_column(
+        "sellers",
+        sa.Column("paystack_subaccount_code", sa.String(length=50), nullable=True),
+    )
+    op.add_column(
+        "sellers",
+        sa.Column("payout_bank_code", sa.String(length=10), nullable=True),
+    )
+    op.add_column(
+        "sellers",
+        sa.Column("payout_account_number", sa.String(length=20), nullable=True),
+    )
+    op.add_column(
+        "sellers",
+        sa.Column("payout_account_name", sa.String(length=100), nullable=True),
+    )
+
+    order_return_status = sa.Enum(
+        "REQUESTED",
+        "APPROVED",
+        "REJECTED",
+        "REFUNDED",
+        name="orderreturnstatus",
+    )
+    topup_status = sa.Enum(
+        "PENDING",
+        "COMPLETED",
+        "FAILED",
+        name="topupstatus",
+    )
+    order_return_status.create(op.get_bind(), checkfirst=True)
+    topup_status.create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "order_returns",
+        sa.Column("id", sa.String(length=12), nullable=False),
+        sa.Column("order_id", sa.String(length=12), nullable=False),
+        sa.Column("buyer_id", sa.Integer(), nullable=False),
+        sa.Column("reason", sa.Text(), nullable=False),
+        sa.Column("status", order_return_status, nullable=False),
+        sa.Column("refund_amount", sa.Float(), nullable=True),
+        sa.Column("seller_notes", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["buyer_id"], ["buyers.id"]),
+        sa.ForeignKeyConstraint(["order_id"], ["orders.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "wallet_topups",
+        sa.Column("id", sa.String(length=12), nullable=False),
+        sa.Column("user_id", sa.String(length=12), nullable=False),
+        sa.Column("amount", sa.Float(), nullable=False),
+        sa.Column("currency", sa.String(length=3), nullable=False),
+        sa.Column("status", topup_status, nullable=False),
+        sa.Column("paystack_reference", sa.String(length=100), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("paystack_reference"),
+    )
+
+
+def downgrade():
+    op.drop_table("wallet_topups")
+    op.drop_table("order_returns")
+    op.drop_column("sellers", "payout_account_name")
+    op.drop_column("sellers", "payout_account_number")
+    op.drop_column("sellers", "payout_bank_code")
+    op.drop_column("sellers", "paystack_subaccount_code")
+    op.drop_column("orders", "paystack_split_used")
+    op.execute("DROP TYPE IF EXISTS topupstatus")
+    op.execute("DROP TYPE IF EXISTS orderreturnstatus")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ def pytest_configure():
     import app.cart.models  # noqa: F401
     import app.chats.models  # noqa: F401
     import app.deliveries.models  # noqa: F401
+    import app.media.models  # noqa: F401
     import app.notifications.models  # noqa: F401
     import app.orders.models  # noqa: F401
     import app.payments.models  # noqa: F401

--- a/tests/test_api_smoke.py
+++ b/tests/test_api_smoke.py
@@ -72,3 +72,9 @@ class TestOrderTrackAuthSmoke:
     def test_track_requires_auth(self, client):
         response = client.get("/api/v1/orders/ORD_TEST01/track")
         assert response.status_code == 401
+
+
+class TestWalletWithdrawalsAuthSmoke:
+    def test_withdrawals_requires_auth(self, client):
+        response = client.get("/api/v1/wallet/withdrawals")
+        assert response.status_code == 401

--- a/tests/test_order_expiry.py
+++ b/tests/test_order_expiry.py
@@ -1,0 +1,21 @@
+"""Tests for unpaid order expiry task."""
+
+from unittest.mock import MagicMock, patch
+
+from app.orders.models import OrderStatus
+from app.orders.tasks import expire_unpaid_orders
+
+
+@patch("app.orders.tasks.session_scope")
+def test_expire_unpaid_orders_cancels_stale(mock_session_scope):
+    stale_order = MagicMock()
+    stale_order.status = OrderStatus.PENDING_PAYMENT
+
+    session = MagicMock()
+    session.query.return_value.filter.return_value.all.return_value = [stale_order]
+    mock_session_scope.return_value.__enter__.return_value = session
+
+    result = expire_unpaid_orders()
+    assert result["expired"] == 1
+    assert stale_order.status == OrderStatus.CANCELLED
+    assert stale_order.cancel_reason is not None

--- a/tests/test_phase2_payments.py
+++ b/tests/test_phase2_payments.py
@@ -1,0 +1,83 @@
+"""Tests for Phase 2 payment and wallet features."""
+
+import hashlib
+import hmac
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from app.payments.models import PaymentMethod
+from app.payments.services import PaymentService
+from app.wallet.models import WalletReferenceType
+from app.wallet.services import WalletService
+
+
+def test_verify_webhook_signature_uses_raw_body():
+    secret = "sk_test_secret"
+    body = b'{"event":"charge.success","data":{}}'
+    signature = hmac.new(secret.encode(), body, hashlib.sha512).hexdigest()
+
+    PaymentService.PAYSTACK_SECRET_KEY = secret
+    assert PaymentService._verify_webhook_signature(signature, body) is True
+    assert PaymentService._verify_webhook_signature(signature, b"{}") is False
+
+
+def test_wallet_payment_method_enum_exists():
+    assert PaymentMethod.WALLET.value == "wallet"
+
+
+@patch("app.payments.services.PaymentService.complete_payment")
+@patch("app.wallet.services.WalletService.pay_for_order")
+def test_create_payment_wallet_debits_and_completes(mock_pay, mock_complete):
+    mock_pay.return_value = MagicMock()
+    mock_complete.return_value = True
+
+    order = SimpleNamespace(
+        id="ORD_TEST01",
+        total=5000.0,
+        subtotal=5000.0,
+        buyer=SimpleNamespace(user_id="USR_BUYER1"),
+    )
+    payment = MagicMock()
+    payment.id = "PAY_TEST01"
+
+    session = MagicMock()
+    session.query.return_value.options.return_value.get.return_value = order
+    session.query.return_value.filter_by.return_value.first.return_value = None
+
+    captured_payment = {}
+
+    def assign_payment_id():
+        if captured_payment.get("payment") is not None:
+            captured_payment["payment"].id = "PAY_TEST01"
+
+    session.flush.side_effect = assign_payment_id
+
+    def capture_add(obj):
+        captured_payment["payment"] = obj
+
+    session.add.side_effect = capture_add
+
+    with patch("app.payments.services.session_scope") as mock_scope:
+        mock_scope.return_value.__enter__.return_value = session
+        with patch(
+            "app.payments.services.PaymentService.get_payment", return_value=payment
+        ):
+            with patch("app.payments.services.PaymentService._cache_payment"):
+                from app.orders.models import OrderStatus
+
+                order.status = OrderStatus.PENDING_PAYMENT
+                PaymentService.create_payment(
+                    order_id="ORD_TEST01",
+                    amount=None,
+                    method=PaymentMethod.WALLET,
+                )
+
+    mock_pay.assert_called_once()
+    mock_complete.assert_called_once_with(payment_id="PAY_TEST01")
+
+
+@patch.object(WalletService, "debit")
+def test_pay_for_order_uses_order_payment_reference(mock_debit):
+    WalletService.pay_for_order("USR_1", "ORD_1", "PAY_1", 1000.0)
+    mock_debit.assert_called_once()
+    assert mock_debit.call_args[0][2] == WalletReferenceType.ORDER_PAYMENT

--- a/tests/test_phase3_marketplace.py
+++ b/tests/test_phase3_marketplace.py
@@ -1,0 +1,159 @@
+"""Tests for Phase 3 marketplace payment features."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.libs.errors import ValidationError
+from app.orders.models import OrderReturnStatus, OrderStatus
+from app.orders.services import OrderService, RETURNABLE_ORDER_STATUSES
+from app.payments.services import PaymentService
+from app.wallet.models import TopUpStatus, WalletReferenceType
+from app.wallet.services import WalletService
+
+
+def test_returnable_order_statuses():
+    assert OrderStatus.SHIPPED in RETURNABLE_ORDER_STATUSES
+    assert OrderStatus.DELIVERED in RETURNABLE_ORDER_STATUSES
+    assert OrderStatus.PENDING_PAYMENT not in RETURNABLE_ORDER_STATUSES
+
+
+@patch("app.wallet.services.WalletService.credit")
+def test_approve_return_credits_buyer_wallet(mock_credit):
+    order = SimpleNamespace(
+        id="ORD_RET001",
+        total=8000.0,
+        buyer=SimpleNamespace(user_id="USR_BUYER1"),
+        items=[SimpleNamespace(seller_id=7, status=SimpleNamespace(value="delivered"))],
+        payments=[SimpleNamespace(status=SimpleNamespace(value="completed"))],
+    )
+    order_return = SimpleNamespace(
+        id="RET_TEST01",
+        status=OrderReturnStatus.REQUESTED,
+        refund_amount=8000.0,
+        order=order,
+        seller_notes=None,
+    )
+
+    session = MagicMock()
+    session.query.return_value.options.return_value.get.return_value = order_return
+
+    with patch("app.orders.services.session_scope") as mock_scope:
+        mock_scope.return_value.__enter__.return_value = session
+        from app.payments.models import PaymentStatus
+
+        for payment in order.payments:
+            payment.status = PaymentStatus.COMPLETED
+        from app.orders.models import OrderItem
+
+        order.items[0].status = OrderItem.Status.DELIVERED
+        OrderService.approve_return("RET_TEST01", seller_id=7)
+
+    mock_credit.assert_called_once()
+    assert mock_credit.call_args.kwargs["idempotency_key"] == "return-refund:RET_TEST01"
+
+
+@patch("app.wallet.services.WalletService.credit")
+def test_complete_topup_is_idempotent(mock_credit):
+    topup = SimpleNamespace(
+        id="TOP_ABC123",
+        user_id="USR_1",
+        amount=5000.0,
+        currency="NGN",
+        status=TopUpStatus.PENDING,
+    )
+
+    session = MagicMock()
+    session.query.return_value.get.return_value = topup
+
+    with patch("app.wallet.services.session_scope") as mock_scope:
+        mock_scope.return_value.__enter__.return_value = session
+        assert WalletService.complete_topup("TOP_TOP_ABC123") is True
+
+    mock_credit.assert_called_once()
+    assert mock_credit.call_args[0][2] == WalletReferenceType.WALLET_TOPUP
+
+
+@patch.object(WalletService, "credit")
+def test_settle_order_item_skips_when_paystack_split_used(mock_credit):
+    item = SimpleNamespace(
+        id=99,
+        order_id="ORD_SPLIT1",
+        price=1000.0,
+        quantity=1,
+        seller=SimpleNamespace(user_id="USR_SELLER"),
+    )
+    order = SimpleNamespace(paystack_split_used=True)
+
+    session = MagicMock()
+    session.query.return_value.get.return_value = order
+
+    with patch("app.wallet.services.session_scope") as mock_scope:
+        mock_scope.return_value.__enter__.return_value = session
+        result = WalletService.settle_order_item(item)
+
+    assert result is None
+    mock_credit.assert_not_called()
+
+
+@patch("app.payments.services.PaymentService.complete_payment")
+@patch("app.wallet.services.WalletService.complete_topup")
+def test_webhook_routes_topup_references(mock_topup, mock_complete):
+    mock_topup.return_value = True
+    data = {"reference": "TOP_123", "metadata": {"type": "wallet_topup"}}
+    assert PaymentService._handle_successful_charge(data) is True
+    mock_topup.assert_called_once()
+    mock_complete.assert_not_called()
+
+
+@patch("app.wallet.paystack_subaccounts.PaystackSubaccountClient.create_subaccount")
+def test_register_seller_payout_account(mock_create):
+    mock_create.return_value = {"subaccount_code": "ACCT_sub123"}
+    seller = SimpleNamespace(
+        id=5,
+        shop_name="Ada Shop",
+        paystack_subaccount_code=None,
+        payout_bank_code=None,
+        payout_account_number=None,
+        payout_account_name=None,
+    )
+
+    session = MagicMock()
+    session.query.return_value.get.return_value = seller
+
+    with patch("app.wallet.services.session_scope") as mock_scope:
+        mock_scope.return_value.__enter__.return_value = session
+        result = WalletService.register_seller_payout_account(
+            5,
+            bank_code="058",
+            account_number="0123456789",
+            account_name="Ada Lovelace",
+        )
+
+    assert result["subaccount_code"] == "ACCT_sub123"
+    mock_create.assert_called_once()
+
+
+def test_initialize_topup_rejects_small_amount():
+    with pytest.raises(ValidationError):
+        WalletService.initialize_topup("USR_1", 50.0)
+
+
+def test_resolve_subaccount_split_single_seller():
+    seller = SimpleNamespace(seller_id=1, paystack_subaccount_code="ACCT_abc")
+    item = SimpleNamespace(seller_id=1, seller=seller)
+    order = SimpleNamespace(items=[item])
+
+    split = PaymentService._resolve_subaccount_split(order)
+    assert split == {"subaccount_code": "ACCT_abc"}
+
+
+def test_resolve_subaccount_split_multi_seller_returns_none():
+    order = SimpleNamespace(
+        items=[
+            SimpleNamespace(seller_id=1, seller=None),
+            SimpleNamespace(seller_id=2, seller=None),
+        ]
+    )
+    assert PaymentService._resolve_subaccount_split(order) is None

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -13,6 +13,7 @@ from app.wallet.services import DEFAULT_COMMISSION_RATE, WalletService
 def test_settle_order_item_calculates_net_after_commission():
     item = SimpleNamespace(
         id=42,
+        order_id="ORD_1",
         price=10000.0,
         quantity=2,
         seller=SimpleNamespace(user_id="USR_SELLER1"),
@@ -20,11 +21,17 @@ def test_settle_order_item_calculates_net_after_commission():
     gross = item.price * item.quantity
     expected_net = round(gross * (1 - DEFAULT_COMMISSION_RATE), 2)
 
-    with patch.object(WalletService, "credit") as mock_credit:
-        mock_credit.return_value = MagicMock()
-        WalletService.settle_order_item(item)
-        mock_credit.assert_called_once()
-        assert mock_credit.call_args[0][1] == expected_net
+    order = SimpleNamespace(paystack_split_used=False)
+    session = MagicMock()
+    session.query.return_value.get.return_value = order
+
+    with patch("app.wallet.services.session_scope") as mock_scope:
+        mock_scope.return_value.__enter__.return_value = session
+        with patch.object(WalletService, "credit") as mock_credit:
+            mock_credit.return_value = MagicMock()
+            WalletService.settle_order_item(item)
+            mock_credit.assert_called_once()
+            assert mock_credit.call_args[0][1] == expected_net
 
 
 def test_credit_rejects_non_positive_amount():


### PR DESCRIPTION
## Description
Delivers the full wallet and marketplace payments layer on top of Phase 0–1 checkout: wallet checkout, Paystack withdrawals, order hygiene, wallet top-ups, returns, and seller split settlements.

### Phase 2 — Wallet payments & hygiene
- `method: wallet` on `POST /payments/create` — debits buyer wallet and completes order in one step
- Paystack Transfer API for `POST /wallet/withdraw` with `transfer.success` / `transfer.failed` webhooks
- Webhook HMAC verification against **raw request body** (Paystack spec)
- Celery hourly task `expire_unpaid_orders` (configurable via `UNPAID_ORDER_EXPIRY_HOURS`)
- `GET /wallet/withdrawals` — withdrawal history

### Phase 3 — Marketplace maturity
- `POST /wallet/topup/initialize` — Paystack top-up; `charge.success` credits wallet via `TOP_*` references
- Order returns: `POST /orders/{id}/returns`, seller approve/reject with wallet refund
- Seller subaccounts: `POST /wallet/seller/payout-account`; single-seller card checkout passes Paystack `subaccount`
- `orders.paystack_split_used` — skips duplicate wallet settlement on delivery when Paystack already split
- Async withdrawals via Celery `app.wallet.tasks.process_withdrawal`

**Suggested branch:** `feat/payments-wallet-marketplace` (base: Phase 1 branch)  
**Suggested commit message:**
```
feat(payments,wallet): wallet checkout, withdrawals, top-ups, returns, and seller splits
```

Or as two commits on the same branch:
```
feat(payments,wallet): enable wallet checkout, Paystack withdrawals, and order expiry
feat(payments,wallet): add top-ups, returns, subaccount splits, and async withdrawals
```

## Tickets
- [Payments] Wallet checkout (`method: wallet`)
- [Wallet] Paystack withdrawal transfers + webhooks
- [Payments] Webhook signature fix (raw body)
- [Orders] Unpaid order expiry job
- [Wallet] Paystack wallet top-up
- [Orders] Returns flow (request / approve / reject)
- [Payments] Paystack subaccount split for single-seller card payments
- [Wallet] Async withdrawal processing

## Related Issue
Completes the marketplace payments roadmap after Phase 0–1 checkout hardening: in-app wallet pay and funding, real bank withdrawals, webhook verification fix, stale order cleanup, post-delivery returns, and automatic seller commission via Paystack splits.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## How Has This Been Tested?

### Unit tests — Phase 2
- `tests/test_phase2_payments.py` — webhook HMAC, wallet payment flow, `ORDER_PAYMENT` reference
- `tests/test_order_expiry.py` — expiry task logic

### Unit tests — Phase 3
- `tests/test_phase3_marketplace.py` — top-up webhook routing, return approval refund, split settlement skip, subaccount registration, split resolution

### Regression
- `tests/test_wallet.py` — settlement commission math, `paystack_split_used` guard
- `tests/test_api_smoke.py` — wallet/withdrawal route registration

```bash
flask db upgrade   # c8d9e0f1a2b3, then d9e0f1a2b3c4
.venv/bin/python -m pytest tests/ -v
```

**Result:** 37 tests passing (full suite).

## Tested & Approved by?
- [ ] QA Engineer

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

### Endpoints (new or changed)
| Method | Path | Role |
|--------|------|------|
| POST | `/api/v1/payments/create` | Buyer — `method: wallet` debits wallet and completes order |
| POST | `/api/v1/wallet/withdraw` | User — request bank withdrawal (Paystack transfer) |
| GET | `/api/v1/wallet/withdrawals` | User — withdrawal history |
| POST | `/api/v1/wallet/topup/initialize` | Buyer — fund wallet via Paystack |
| POST | `/api/v1/wallet/seller/payout-account` | Seller — register bank + subaccount |
| POST | `/api/v1/orders/{id}/returns` | Buyer — request return |
| POST | `/api/v1/orders/returns/{id}/approve` | Seller — approve + wallet refund |
| POST | `/api/v1/orders/returns/{id}/reject` | Seller — reject return |

### Wallet payment
```json
POST /api/v1/payments/create
{ "order_id": "ORD_...", "method": "wallet" }
```
Amount is derived server-side from `order.total`.

### Return rules
Returns allowed for `shipped` and `delivered` orders only. Approved returns set order → `returned` and credit buyer wallet. Other statuses use the cancel flow (Phase 1).

### Split payment
When an order has exactly one seller with a registered Paystack subaccount, card initialize includes `subaccount`. Internal seller settlement on delivery is skipped (`paystack_split_used=true`) to avoid double-paying the seller.

### Config
- `UNPAID_ORDER_EXPIRY_HOURS` (default `48`)
- `PLATFORM_COMMISSION_RATE` (default `0.10`)

### Migrations
| Revision | Contents |
|----------|----------|
| `c8d9e0f1a2b3` | `ORDER_PAYMENT` wallet reference enum |
| `d9e0f1a2b3c4` | `wallet_topups`, `order_returns`, seller payout columns, `orders.paystack_split_used` |

### Celery
- **Beat:** `app.orders.tasks.expire_unpaid_orders` (hourly)
- **Worker:** `app.wallet.tasks.process_withdrawal` on `default` queue

Ensure worker + beat are running in deployed environments.

### Deployment
1. Run migrations through `d9e0f1a2b3c4`
2. Configure `PAYSTACK_SECRET_KEY` / `PAYSTACK_PUBLIC_KEY`
3. Start Celery worker (default queue) and beat
4. Sellers register payout account before split-at-pay applies to their orders


### PR stack context
This PR builds on Phase 0 (checkout hardening) and Phase 1 (cancel / track / wallet ledger). Phases 0–1 can land as separate PRs; this combined PR covers all wallet and marketplace payment work from Phase 2 onward.
