### PR TITLE
fix(media/services.py): increase max image dimensions to 5000x5000

### DIFF
--- a/app/media/services.py
+++ b/app/media/services.py
@@ -51,7 +51,7 @@ class MediaService:
         # Image size limits
         self.image_limits = {
             "max_size": 10 * 1024 * 1024,  # 10MB
-            "max_dimensions": (4000, 4000),
+            "max_dimensions": (5000, 5000),
             "allowed_formats": [".jpg", ".jpeg", ".png", ".webp", ".gif"],
         }
 


### PR DESCRIPTION
## Description
changed image dimensions from 4000 x 4000 to 5000 x 5000 to cater for larger images with a limit

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
