### PR TITLE
feat: implement gamification MVP with points ledger, stats, badges, t…

### DIFF
--- a/app/gamification/badge_engine.py
+++ b/app/gamification/badge_engine.py
@@ -1,0 +1,87 @@
+"""Criteria DSL evaluator for badges (spec §4.3, Appendix B).
+
+criteria_json shape:
+    {
+      "all": [{"stat": "total_sales", "op": ">=", "value": 10}, ...],   # AND
+      "any": [{...}, ...],                                              # OR
+      "trigger": ["order.completed", ...]
+    }
+
+Stats are a flat dict of {stat_name: number}; a missing stat is treated as 0.
+Everything here is pure so it is trivially unit-testable.
+"""
+
+from typing import Dict, List
+
+_OPS = {
+    ">=": lambda a, b: a >= b,
+    ">": lambda a, b: a > b,
+    "<=": lambda a, b: a <= b,
+    "<": lambda a, b: a < b,
+    "==": lambda a, b: a == b,
+    "!=": lambda a, b: a != b,
+}
+
+
+def _stat_value(stats: Dict, name: str) -> float:
+    try:
+        return float(stats.get(name, 0) or 0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _check(condition: Dict, stats: Dict) -> bool:
+    op = _OPS.get(condition.get("op"))
+    if op is None:
+        return False
+    return op(
+        _stat_value(stats, condition.get("stat")), float(condition.get("value", 0))
+    )
+
+
+def evaluate(criteria: Dict, stats: Dict) -> bool:
+    """Return True if the user's stats satisfy the criteria."""
+    if not criteria:
+        return False
+
+    all_conds = criteria.get("all") or []
+    any_conds = criteria.get("any") or []
+
+    if all_conds and not all(_check(c, stats) for c in all_conds):
+        return False
+    if any_conds and not any(_check(c, stats) for c in any_conds):
+        return False
+    # Must have at least one condition group to be awardable.
+    return bool(all_conds or any_conds)
+
+
+def triggers(criteria: Dict) -> List[str]:
+    """Events that should re-evaluate this badge."""
+    if not criteria:
+        return []
+    return list(criteria.get("trigger") or [])
+
+
+def progress(criteria: Dict, stats: Dict) -> float:
+    """Best-effort 0..1 progress for locked-badge display.
+
+    Uses the minimum ratio across the "all" conditions (the binding constraint).
+    Non-threshold ops (<, ==) that are already satisfied count as complete;
+    otherwise they contribute 0 so the badge reads as incomplete.
+    """
+    conds = (criteria or {}).get("all") or (criteria or {}).get("any") or []
+    if not conds:
+        return 0.0
+
+    ratios = []
+    for c in conds:
+        target = float(c.get("value", 0) or 0)
+        current = _stat_value(stats, c.get("stat"))
+        op = c.get("op")
+        if op in (">=", ">"):
+            ratios.append(1.0 if target <= 0 else min(1.0, current / target))
+        else:
+            # For "less than / equals" style gates, we can't show a smooth bar;
+            # collapse to met/unmet.
+            ratios.append(1.0 if _check(c, stats) else 0.0)
+    return round(min(ratios), 4) if ratios else 0.0

--- a/app/gamification/constants.py
+++ b/app/gamification/constants.py
@@ -1,0 +1,265 @@
+"""Gamification configuration constants.
+
+Per the MVP spec (Appendix A/B/C) these values are intentionally kept out of the
+awarding/evaluation code paths so the team can iterate on balance without a
+migration. The tier table and badge catalog are also seeded into the database
+(gam_tier_config / gam_badges) from these definitions so they can additionally
+be edited at runtime; these serve as the source-of-truth seed and a safe
+fallback.
+"""
+
+# --- Point values (Appendix A) -------------------------------------------------
+# reason_key -> points awarded. Reversible order awards are clawed back with a
+# negative ledger entry (see REASON_REVERSAL).
+POINT_VALUES = {
+    "order_completed_buyer": 50,
+    "order_completed_seller": 100,
+    "review_with_photo": 25,
+    "review_text_only": 10,
+    "post_created": 5,
+    "post_reaction_received": 1,
+    "profile_completed": 50,
+    "referral_first_paid": 200,
+    "daily_first_login": 2,
+}
+
+# Reason written when a previously-awarded order is refunded/cancelled.
+REASON_ORDER_REVERSED = "order_reversed"
+
+# --- Daily anti-abuse caps (Appendix A / §5.8) ---------------------------------
+# reason_key -> max number of point-eligible awards per user per calendar day.
+# Further events still succeed (e.g. the post publishes) but award 0 points.
+DAILY_CAPS = {
+    "post_created": 5,
+    "post_reaction_received": 20,
+}
+
+# --- Reference types (ledger.ref_type) -----------------------------------------
+REF_ORDER = "order"
+REF_POST = "post"
+REF_REVIEW = "review"
+REF_USER = "user"
+REF_REACTION = "reaction"
+
+# --- Tiers / Stars (Appendix C) ------------------------------------------------
+# Ordered ascending by min_lifetime_points. Colours are placeholders pending the
+# Blink Graphics palette; the API exposes them so the client never hard-codes.
+TIER_SEED = [
+    {
+        "tier": "newcomer",
+        "name": "Newcomer",
+        "star_count": 0,
+        "min_lifetime_points": 0,
+        "color_hex": "#5C677D",
+    },
+    {
+        "tier": "hustler",
+        "name": "Hustler",
+        "star_count": 1,
+        "min_lifetime_points": 100,
+        "color_hex": "#A0522D",
+    },
+    {
+        "tier": "trader",
+        "name": "Trader",
+        "star_count": 2,
+        "min_lifetime_points": 500,
+        "color_hex": "#9AA0A6",
+    },
+    {
+        "tier": "merchant",
+        "name": "Merchant",
+        "star_count": 3,
+        "min_lifetime_points": 1500,
+        "color_hex": "#E36414",
+    },
+    {
+        "tier": "magnate",
+        "name": "Magnate",
+        "star_count": 4,
+        "min_lifetime_points": 5000,
+        "color_hex": "#0F4C5C",
+    },
+    {
+        "tier": "mogul",
+        "name": "Mogul",
+        "star_count": 5,
+        "min_lifetime_points": 15000,
+        "color_hex": "#3A86FF",
+    },
+]
+
+DEFAULT_TIER_KEY = "newcomer"
+
+# Early Bird badge window: users who joined within EARLY_BIRD_WINDOW_DAYS of the
+# gamification launch qualify. (ISO date; adjust to the real launch date.)
+GAMIFICATION_LAUNCH_DATE = "2026-07-01"
+EARLY_BIRD_WINDOW_DAYS = 30
+
+# --- Badge catalog (Appendix B) ------------------------------------------------
+# audience: "S" seller, "B" buyer, "BS" either.
+# criteria_json is a tiny DSL evaluated by badge_engine against a stats dict:
+#   {"all": [{"stat": <name>, "op": <op>, "value": <n>}, ...], "trigger": [events]}
+# "any" is also supported. Stats are assembled by services.get_badge_stats().
+BADGE_SEED = [
+    {
+        "slug": "verified_seller",
+        "name": "Verified Seller",
+        "audience": "S",
+        "category": "trust",
+        "priority": 100,
+        "description": "Completed identity verification.",
+        "criteria_json": {
+            "all": [{"stat": "is_verified_seller", "op": ">=", "value": 1}],
+            "trigger": ["seller.verified", "order.completed"],
+        },
+    },
+    {
+        "slug": "first_sale",
+        "name": "First Sale",
+        "audience": "S",
+        "category": "milestone",
+        "priority": 60,
+        "description": "Completed your first sale.",
+        "criteria_json": {
+            "all": [{"stat": "total_sales", "op": ">=", "value": 1}],
+            "trigger": ["order.completed"],
+        },
+    },
+    {
+        "slug": "top_seller",
+        "name": "Top Seller",
+        "audience": "S",
+        "category": "performance",
+        "priority": 90,
+        "description": "Completed 50 lifetime sales.",
+        "criteria_json": {
+            "all": [{"stat": "total_sales", "op": ">=", "value": 50}],
+            "trigger": ["order.completed"],
+        },
+    },
+    {
+        "slug": "fast_shipper",
+        "name": "Fast Shipper",
+        "audience": "S",
+        "category": "performance",
+        "priority": 80,
+        "description": "Average ship time under 24 hours over 10+ orders.",
+        "criteria_json": {
+            "all": [
+                {"stat": "total_sales", "op": ">=", "value": 10},
+                {"stat": "avg_ship_hours", "op": "<", "value": 24},
+            ],
+            "trigger": ["order.completed"],
+        },
+    },
+    {
+        "slug": "five_star_service",
+        "name": "5-Star Service",
+        "audience": "S",
+        "category": "performance",
+        "priority": 85,
+        "description": "Average rating of 4.8+ over 20 or more reviews.",
+        "criteria_json": {
+            "all": [
+                {"stat": "review_count", "op": ">=", "value": 20},
+                {"stat": "avg_rating", "op": ">=", "value": 4.8},
+            ],
+            "trigger": ["review.created"],
+        },
+    },
+    {
+        "slug": "community_voice",
+        "name": "Community Voice",
+        "audience": "BS",
+        "category": "milestone",
+        "priority": 50,
+        "description": "Earned 100 cumulative reactions on your posts.",
+        "criteria_json": {
+            "all": [{"stat": "total_reactions_received", "op": ">=", "value": 100}],
+            "trigger": ["post.reaction_added"],
+        },
+    },
+    {
+        "slug": "trendsetter",
+        "name": "Trendsetter",
+        "audience": "S",
+        "category": "performance",
+        "priority": 70,
+        "description": "A single post drove 5 or more orders.",
+        # Attribution is a V2 mechanic; seeded inactive so it never mis-awards.
+        "is_active": False,
+        "criteria_json": {
+            "all": [{"stat": "best_post_driven_orders", "op": ">=", "value": 5}],
+            "trigger": ["order.completed"],
+        },
+    },
+    {
+        "slug": "early_bird",
+        "name": "Early Bird",
+        "audience": "BS",
+        "category": "milestone",
+        "priority": 40,
+        "description": "Joined in the first month after launch.",
+        "criteria_json": {
+            "all": [{"stat": "is_early_member", "op": ">=", "value": 1}],
+            "trigger": ["order.completed", "post.created", "profile.completed"],
+        },
+    },
+    {
+        "slug": "loyal_buyer",
+        "name": "Loyal Buyer",
+        "audience": "B",
+        "category": "milestone",
+        "priority": 55,
+        "description": "Completed 10 purchases.",
+        "criteria_json": {
+            "all": [{"stat": "completed_purchases", "op": ">=", "value": 10}],
+            "trigger": ["order.completed"],
+        },
+    },
+    {
+        "slug": "repeat_customer",
+        "name": "Repeat Customer",
+        "audience": "BS",
+        "category": "milestone",
+        "priority": 45,
+        "description": "Bought from the same seller 3 or more times.",
+        "criteria_json": {
+            "all": [{"stat": "max_same_seller_purchases", "op": ">=", "value": 3}],
+            "trigger": ["order.completed"],
+        },
+    },
+]
+
+# --- Redis key patterns (§5.4) -------------------------------------------------
+# Namespaced under "gam:" so gamification data can be flushed independently.
+LB_SCOPE_GLOBAL = "global"
+LB_SCOPE_BUYERS = "buyers"
+LB_SCOPE_SELLERS = "sellers"
+LB_SCOPES = (LB_SCOPE_GLOBAL, LB_SCOPE_BUYERS, LB_SCOPE_SELLERS)
+
+LB_PERIOD_ALLTIME = "alltime"
+LB_PERIOD_WEEKLY = "weekly"
+LB_PERIODS = (LB_PERIOD_ALLTIME, LB_PERIOD_WEEKLY)
+
+STATS_CACHE_TTL_SECONDS = 60
+
+
+def lb_key(scope: str, period: str, period_key: str = None) -> str:
+    """Redis sorted-set key for a leaderboard.
+
+    All-time global has no period suffix; every other combination is keyed by
+    the ISO week (e.g. '2026-W30').
+    """
+    if period == LB_PERIOD_ALLTIME:
+        return f"gam:lb:{scope}:alltime"
+    return f"gam:lb:{scope}:weekly:{period_key}"
+
+
+def stats_cache_key(user_id: str) -> str:
+    return f"gam:stats:{user_id}"
+
+
+def ratelimit_key(reason: str, user_id: str, day: str) -> str:
+    return f"gam:ratelimit:{reason}:{user_id}:{day}"

--- a/app/gamification/events.py
+++ b/app/gamification/events.py
@@ -1,0 +1,237 @@
+"""Signal handlers that translate domain events into point awards and badge
+evaluations (spec §5.3).
+
+Every handler is wrapped so a gamification failure can never break the host
+action that emitted the signal — awarding points is strictly a side-effect.
+Importing this module connects the handlers; it is imported from routes.py so
+registration happens when the blueprint loads.
+"""
+
+import functools
+import logging
+from datetime import datetime
+
+from app.signals import (
+    order_completed,
+    order_reversed,
+    post_created,
+    post_reaction_added,
+    review_created,
+    profile_completed,
+    referral_first_paid,
+    daily_login,
+    seller_verified,
+)
+from . import services
+from .constants import REF_ORDER, REF_POST, REF_REVIEW, REF_USER, REF_REACTION
+
+logger = logging.getLogger(__name__)
+
+
+def _safe(fn):
+    @functools.wraps(fn)
+    def wrapper(sender, **kw):
+        try:
+            return fn(sender, **kw)
+        except Exception as e:  # pragma: no cover - never break the emitter
+            logger.error(f"gamification handler {fn.__name__} failed: {e}")
+
+    return wrapper
+
+
+def _order_id_of(order=None, order_id=None):
+    """Accept either an ORM order (possibly detached) or an explicit id."""
+    if order_id:
+        return order_id
+    return getattr(order, "id", None)
+
+
+def _resolve_participants(order_id):
+    """(buyer_user_id, {seller_user_ids}) for an order, freshly attached.
+
+    Signals are emitted post-commit so any passed ORM instance is detached; we
+    re-query in our own session to safely walk buyer/items/sellers.
+    """
+    from app.libs.session import session_scope
+    from app.orders.models import Order, OrderItem
+    from external.database import db
+
+    buyer_user_id = None
+    seller_ids = set()
+    with session_scope() as session:
+        order = (
+            session.query(Order)
+            .options(
+                db.joinedload(Order.buyer),
+                db.joinedload(Order.items).joinedload(OrderItem.seller),
+            )
+            .get(order_id)
+        )
+        if order is None:
+            return (None, set())
+        if order.buyer:
+            buyer_user_id = order.buyer.user_id
+        for item in order.items or []:
+            if item.seller and item.seller.user_id:
+                seller_ids.add(item.seller.user_id)
+    return (buyer_user_id, seller_ids)
+
+
+@order_completed.connect
+@_safe
+def _on_order_completed(sender, order=None, order_id=None, **kw):
+    oid = _order_id_of(order, order_id)
+    if not oid:
+        return
+    buyer_user_id, seller_ids = _resolve_participants(oid)
+    if buyer_user_id:
+        services.award_by_reason(
+            buyer_user_id, "order_completed_buyer", ref_type=REF_ORDER, ref_id=oid
+        )
+        services.evaluate_badges_for(buyer_user_id, "order.completed")
+
+    for seller_user_id in seller_ids:
+        services.award_by_reason(
+            seller_user_id,
+            "order_completed_seller",
+            ref_type=REF_ORDER,
+            ref_id=oid,
+        )
+        services.record_sale(seller_user_id)
+        services.evaluate_badges_for(seller_user_id, "order.completed")
+
+
+@order_reversed.connect
+@_safe
+def _on_order_reversed(sender, order=None, order_id=None, **kw):
+    oid = _order_id_of(order, order_id)
+    if not oid:
+        return
+    buyer_user_id, seller_ids = _resolve_participants(oid)
+    if buyer_user_id:
+        services.reverse_award(
+            buyer_user_id,
+            "order_completed_buyer",
+            REF_ORDER,
+            oid,
+            "order_reversed",
+        )
+    for seller_user_id in seller_ids:
+        services.reverse_award(
+            seller_user_id,
+            "order_completed_seller",
+            REF_ORDER,
+            oid,
+            "order_reversed",
+        )
+
+
+@post_created.connect
+@_safe
+def _on_post_created(sender, post=None, **kw):
+    if post is None or not getattr(post, "user_id", None):
+        return
+    services.award_by_reason(
+        post.user_id, "post_created", ref_type=REF_POST, ref_id=post.id
+    )
+    services.evaluate_badges_for(post.user_id, "post.created")
+
+
+@post_reaction_added.connect
+@_safe
+def _on_post_reaction_added(sender, post=None, reactor_id=None, **kw):
+    if post is None or not getattr(post, "user_id", None):
+        return
+    # Don't reward self-reactions.
+    if reactor_id and reactor_id == post.user_id:
+        return
+    # ref uniquely identifies (post, reactor) so the same reactor can't farm the
+    # same post; the daily cap bounds the rest.
+    ref = f"{post.id}:{reactor_id}"
+    services.award_by_reason(
+        post.user_id, "post_reaction_received", ref_type=REF_REACTION, ref_id=ref
+    )
+    services.evaluate_badges_for(post.user_id, "post.reaction_added")
+
+
+@review_created.connect
+@_safe
+def _on_review_created(sender, review=None, **kw):
+    if review is None:
+        return
+    reviewer_id = getattr(review, "user_id", None)
+    review_id = getattr(review, "id", None)
+    rating = getattr(review, "rating", None)
+    product_id = getattr(review, "product_id", None)
+    # Reviews carry no media in the current schema, so all reviews are text-only.
+    # getattr keeps this forward-compatible if a photo field is added later.
+    has_photo = bool(
+        getattr(review, "images", None) or getattr(review, "has_photo", False)
+    )
+
+    if reviewer_id and review_id is not None:
+        reason = "review_with_photo" if has_photo else "review_text_only"
+        services.award_by_reason(
+            reviewer_id, reason, ref_type=REF_REVIEW, ref_id=review_id
+        )
+
+    # Resolve the reviewed seller in a fresh session (signal fires post-commit,
+    # so `review.product.seller` would otherwise be a detached lazy-load).
+    if product_id and rating is not None:
+        seller_user_id = _seller_user_of_product(product_id)
+        if seller_user_id:
+            services.record_review(seller_user_id, rating)
+            services.evaluate_badges_for(seller_user_id, "review.created")
+
+
+def _seller_user_of_product(product_id):
+    from app.libs.session import session_scope
+    from app.products.models import Product
+
+    try:
+        with session_scope() as session:
+            product = session.query(Product).get(product_id)
+            seller = getattr(product, "seller", None) if product else None
+            return getattr(seller, "user_id", None) if seller else None
+    except Exception:
+        return None
+
+
+@profile_completed.connect
+@_safe
+def _on_profile_completed(sender, user_id=None, **kw):
+    if not user_id:
+        return
+    services.award_by_reason(
+        user_id, "profile_completed", ref_type=REF_USER, ref_id=user_id
+    )
+    services.evaluate_badges_for(user_id, "profile.completed")
+
+
+@referral_first_paid.connect
+@_safe
+def _on_referral_first_paid(sender, referrer_id=None, referee_id=None, **kw):
+    if not referrer_id:
+        return
+    services.award_by_reason(
+        referrer_id, "referral_first_paid", ref_type=REF_USER, ref_id=referee_id
+    )
+
+
+@daily_login.connect
+@_safe
+def _on_daily_login(sender, user_id=None, **kw):
+    if not user_id:
+        return
+    day = datetime.utcnow().strftime("%Y%m%d")
+    services.award_by_reason(
+        user_id, "daily_first_login", ref_type="day", ref_id=f"{user_id}:{day}"
+    )
+
+
+@seller_verified.connect
+@_safe
+def _on_seller_verified(sender, user_id=None, **kw):
+    if not user_id:
+        return
+    services.evaluate_badges_for(user_id, "seller.verified")

--- a/app/gamification/leaderboard.py
+++ b/app/gamification/leaderboard.py
@@ -1,0 +1,151 @@
+"""Redis-backed leaderboard ranking utilities (spec §4.4, §5.4).
+
+Live ranks live in sorted sets, updated atomically on every award. Score is the
+user's points in the period (lifetime for all-time, weekly for weekly). The
+buyers/sellers scopes are the same score filtered to that audience.
+
+Opt-out: opted-out users remain in the sorted sets (so their own "your rank"
+stays accurate) but are recorded in a side SET and filtered out of the public
+listing.
+"""
+
+import logging
+from datetime import datetime, date
+from typing import List, Dict, Optional
+
+from external.redis import redis_client
+from .constants import (
+    lb_key,
+    LB_SCOPE_GLOBAL,
+    LB_SCOPE_BUYERS,
+    LB_SCOPE_SELLERS,
+    LB_PERIOD_ALLTIME,
+    LB_PERIOD_WEEKLY,
+)
+
+logger = logging.getLogger(__name__)
+
+_OPTOUT_KEY = "gam:lb:optout"
+
+
+def current_week_key(when: datetime = None) -> str:
+    """ISO week key, e.g. '2026-W30'."""
+    d = (when or datetime.utcnow()).date()
+    iso = d.isocalendar()
+    return f"{iso[0]}-W{iso[1]:02d}"
+
+
+def _scopes_for(is_buyer: bool, is_seller: bool) -> List[str]:
+    scopes = [LB_SCOPE_GLOBAL]
+    if is_buyer:
+        scopes.append(LB_SCOPE_BUYERS)
+    if is_seller:
+        scopes.append(LB_SCOPE_SELLERS)
+    return scopes
+
+
+def apply_award(
+    user_id: str,
+    delta: int,
+    lifetime_points: int,
+    weekly_points: int,
+    is_buyer: bool,
+    is_seller: bool,
+    week_key: str = None,
+) -> None:
+    """Fire-and-forget ZSET update after a successful ledger commit.
+
+    All-time sets are set to the absolute lifetime total (idempotent even if a
+    prior Redis write was lost); weekly sets to the weekly total. If Redis is
+    down the daily snapshot job rebuilds from SQL, so failures are swallowed.
+    """
+    week_key = week_key or current_week_key()
+    try:
+        pipe = redis_client.pipeline()
+        for scope in _scopes_for(is_buyer, is_seller):
+            pipe.zadd(lb_key(scope, LB_PERIOD_ALLTIME), {user_id: lifetime_points})
+            pipe.zadd(
+                lb_key(scope, LB_PERIOD_WEEKLY, week_key), {user_id: weekly_points}
+            )
+        pipe.execute()
+    except Exception as e:  # pragma: no cover - Redis best-effort
+        logger.warning(f"leaderboard.apply_award failed for {user_id}: {e}")
+
+
+def _is_opted_out(user_id: str) -> bool:
+    try:
+        return redis_client.client.sismember(_OPTOUT_KEY, user_id)
+    except Exception:
+        return False
+
+
+def set_opt_out(user_id: str, opted_out: bool) -> None:
+    try:
+        if opted_out:
+            redis_client.sadd(_OPTOUT_KEY, user_id)
+        else:
+            redis_client.srem(_OPTOUT_KEY, user_id)
+    except Exception as e:  # pragma: no cover
+        logger.warning(f"leaderboard.set_opt_out failed for {user_id}: {e}")
+
+
+def _key(scope: str, period: str, week_key: str = None) -> str:
+    return lb_key(scope, period, week_key or current_week_key())
+
+
+def get_page(
+    scope: str, period: str, limit: int = 50, offset: int = 0, week_key: str = None
+) -> List[Dict]:
+    """Top-N rows for a scope/period, opted-out users filtered out.
+
+    Ranks are the true 1-based position in the set, so hidden users leave a gap
+    rather than shifting everyone up.
+    """
+    key = _key(scope, period, week_key)
+    try:
+        raw = redis_client.zrevrange(key, offset, offset + limit - 1, withscores=True)
+    except Exception as e:
+        logger.warning(f"leaderboard.get_page failed for {key}: {e}")
+        return []
+
+    rows = []
+    for idx, (user_id, score) in enumerate(raw):
+        if _is_opted_out(user_id):
+            continue
+        rows.append(
+            {"user_id": user_id, "points": int(score), "rank": offset + idx + 1}
+        )
+    return rows
+
+
+def get_user_rank(
+    scope: str, period: str, user_id: str, week_key: str = None
+) -> Optional[Dict]:
+    """The user's own rank row (accurate even if opted out)."""
+    key = _key(scope, period, week_key)
+    try:
+        rank = redis_client.client.zrevrank(key, user_id)
+        if rank is None:
+            return None
+        score = redis_client.zscore(key, user_id)
+        out_of = redis_client.zcard(key)
+        return {
+            "scope": scope,
+            "period": period,
+            "rank": rank + 1,
+            "points": int(score or 0),
+            "out_of": int(out_of or 0),
+        }
+    except Exception as e:
+        logger.warning(f"leaderboard.get_user_rank failed for {key}: {e}")
+        return None
+
+
+def seed_member(
+    scope: str, period: str, user_id: str, points: int, week_key: str = None
+) -> None:
+    """Used by the cold-start rebuild to load a single member."""
+    try:
+        redis_client.zadd(_key(scope, period, week_key), {user_id: points})
+    except Exception as e:  # pragma: no cover
+        logger.warning(f"leaderboard.seed_member failed: {e}")

--- a/app/gamification/models.py
+++ b/app/gamification/models.py
@@ -1,0 +1,153 @@
+"""Gamification ORM models (all tables prefixed gam_).
+
+Design notes (spec §5.2):
+- No existing table is modified. Foreign keys point *into* users only, so the
+  whole feature can be rolled forward/back independently.
+- The ledger carries a unique partial index on
+  (user_id, reason, ref_type, ref_id) WHERE ref_id IS NOT NULL — the single
+  most important idempotency guard against double-credits.
+"""
+
+from sqlalchemy import Index, UniqueConstraint, text
+
+from external.database import db
+from app.libs.models import BaseModel
+
+
+class PointsLedger(BaseModel):
+    """Append-only audit of every credit/debit."""
+
+    __tablename__ = "gam_points_ledger"
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(
+        db.String(12), db.ForeignKey("users.id"), nullable=False, index=True
+    )
+    delta = db.Column(db.Integer, nullable=False)
+    reason = db.Column(db.String(64), nullable=False)
+    ref_type = db.Column(db.String(32), nullable=True)
+    ref_id = db.Column(db.String(64), nullable=True)
+    balance_after = db.Column(db.Integer, nullable=False, default=0)
+
+    __table_args__ = (
+        # Idempotency: the same (reason, ref) can only be credited once. Partial
+        # so that ad-hoc awards without a ref_id (e.g. daily login handled by a
+        # separate key) are not constrained here.
+        Index(
+            "uq_gam_ledger_idempotency",
+            "user_id",
+            "reason",
+            "ref_type",
+            "ref_id",
+            unique=True,
+            postgresql_where=text("ref_id IS NOT NULL"),
+        ),
+        Index("ix_gam_ledger_user_created", "user_id", "created_at"),
+        Index("ix_gam_ledger_ref", "ref_type", "ref_id"),
+    )
+
+
+class UserStats(BaseModel):
+    """Denormalised running totals for fast profile reads."""
+
+    __tablename__ = "gam_user_stats"
+
+    user_id = db.Column(db.String(12), db.ForeignKey("users.id"), primary_key=True)
+    lifetime_points = db.Column(db.Integer, nullable=False, default=0)
+    available_points = db.Column(db.Integer, nullable=False, default=0)
+    weekly_points = db.Column(db.Integer, nullable=False, default=0)
+    weekly_period = db.Column(db.String(8), nullable=True)  # e.g. "2026-W30"
+    current_tier = db.Column(db.String(20), nullable=False, default="newcomer")
+
+
+class SellerStats(BaseModel):
+    """Aggregates that feed seller badge criteria.
+
+    Public columns (total_sales, avg_rating, avg_ship_hours, on_time_pct) are
+    derived from the accumulators so averages update incrementally without a
+    full recompute.
+    """
+
+    __tablename__ = "gam_seller_stats"
+
+    user_id = db.Column(db.String(12), db.ForeignKey("users.id"), primary_key=True)
+    total_sales = db.Column(db.Integer, nullable=False, default=0)
+
+    # Rating accumulators -> avg_rating.
+    review_count = db.Column(db.Integer, nullable=False, default=0)
+    rating_sum = db.Column(db.Float, nullable=False, default=0.0)
+    avg_rating = db.Column(db.Float, nullable=False, default=0.0)
+
+    # Shipping accumulators -> avg_ship_hours / on_time_pct.
+    ship_count = db.Column(db.Integer, nullable=False, default=0)
+    ship_hours_sum = db.Column(db.Float, nullable=False, default=0.0)
+    on_time_count = db.Column(db.Integer, nullable=False, default=0)
+    avg_ship_hours = db.Column(db.Float, nullable=True)
+    on_time_pct = db.Column(db.Float, nullable=True)
+
+
+class Badge(BaseModel):
+    """Static catalog row; criteria evaluated by badge_engine."""
+
+    __tablename__ = "gam_badges"
+
+    id = db.Column(db.Integer, primary_key=True)
+    slug = db.Column(db.String(64), unique=True, nullable=False)
+    name = db.Column(db.String(120), nullable=False)
+    description = db.Column(db.Text, nullable=True)
+    icon_url = db.Column(db.String(255), nullable=True)
+    category = db.Column(db.String(32), nullable=True)  # trust/performance/milestone
+    audience = db.Column(db.String(2), nullable=False, default="BS")  # S/B/BS
+    priority = db.Column(db.Integer, nullable=False, default=0)
+    criteria_json = db.Column(db.JSON, nullable=False, default=dict)
+    is_active = db.Column(db.Boolean, nullable=False, default=True)
+
+
+class UserBadge(BaseModel):
+    """One row per (user, badge) once earned."""
+
+    __tablename__ = "gam_user_badges"
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(
+        db.String(12), db.ForeignKey("users.id"), nullable=False, index=True
+    )
+    badge_id = db.Column(db.Integer, db.ForeignKey("gam_badges.id"), nullable=False)
+    awarded_at = db.Column(db.DateTime, server_default=db.func.now())
+    progress_json = db.Column(db.JSON, nullable=True)
+
+    badge = db.relationship("Badge")
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "badge_id", name="uq_gam_user_badge"),
+    )
+
+
+class TierConfig(BaseModel):
+    """Editable tier table seeded from constants.TIER_SEED."""
+
+    __tablename__ = "gam_tier_config"
+
+    tier = db.Column(db.String(20), primary_key=True)  # tier key
+    name = db.Column(db.String(50), nullable=False)
+    min_lifetime_points = db.Column(db.Integer, nullable=False)
+    color_hex = db.Column(db.String(7), nullable=False)
+    star_count = db.Column(db.Integer, nullable=False)
+
+
+class LeaderboardSnapshot(BaseModel):
+    """Daily archival snapshot; powers historical views and Redis cold-start."""
+
+    __tablename__ = "gam_leaderboard_snapshot"
+
+    id = db.Column(db.Integer, primary_key=True)
+    scope = db.Column(db.String(20), nullable=False)
+    period_key = db.Column(db.String(20), nullable=False)
+    user_id = db.Column(db.String(12), db.ForeignKey("users.id"), nullable=False)
+    rank = db.Column(db.Integer, nullable=False)
+    points = db.Column(db.Integer, nullable=False)
+    captured_at = db.Column(db.DateTime, server_default=db.func.now())
+
+    __table_args__ = (
+        Index("ix_gam_lb_snapshot_scope_period_rank", "scope", "period_key", "rank"),
+    )

--- a/app/gamification/routes.py
+++ b/app/gamification/routes.py
@@ -1,0 +1,120 @@
+"""Gamification REST endpoints (spec §5.5).
+
+Session auth via Flask-Login; Marshmallow schemas drive the OpenAPI contract.
+Importing `events` here wires the domain-signal handlers when the blueprint
+loads.
+"""
+
+import logging
+
+from flask_smorest import Blueprint, abort
+from flask.views import MethodView
+from flask_login import current_user
+
+from app.libs.decorators import login_required
+
+from . import services
+from . import events  # noqa: F401 - importing registers signal handlers
+from .schemas import (
+    GamMeSchema,
+    PublicProfileSchema,
+    PointsHistoryResponseSchema,
+    HistoryQueryArgs,
+    LeaderboardResponseSchema,
+    LeaderboardQueryArgs,
+    BadgeCatalogResponseSchema,
+    UserBadgesResponseSchema,
+    TierConfigSchema,
+    PreferencesUpdateSchema,
+    PreferencesResponseSchema,
+)
+
+logger = logging.getLogger(__name__)
+
+bp = Blueprint(
+    "gamification",
+    __name__,
+    description="Points, tiers, badges and leaderboard",
+    url_prefix="/gamification",
+)
+
+
+@bp.route("/me")
+class MyGamification(MethodView):
+    @login_required
+    @bp.response(200, GamMeSchema)
+    def get(self):
+        """Current user's stats, tier, badge count and weekly rank."""
+        return services.get_me(current_user.id)
+
+
+@bp.route("/me/preferences")
+class MyPreferences(MethodView):
+    @login_required
+    @bp.arguments(PreferencesUpdateSchema)
+    @bp.response(200, PreferencesResponseSchema)
+    def patch(self, data):
+        """Toggle leaderboard opt-out and similar settings."""
+        return services.set_preferences(
+            current_user.id, opt_out_leaderboard=data.get("opt_out_leaderboard")
+        )
+
+
+@bp.route("/users/<user_id>/profile")
+class PublicProfile(MethodView):
+    @bp.response(200, PublicProfileSchema)
+    def get(self, user_id):
+        """Public gamification profile: badges, tier, lifetime points."""
+        return services.get_public_profile(user_id)
+
+
+@bp.route("/users/<user_id>/badges")
+class UserBadges(MethodView):
+    @bp.response(200, UserBadgesResponseSchema)
+    def get(self, user_id):
+        """Badges held by a user, with progress on locked ones."""
+        return services.get_user_badges(user_id)
+
+
+@bp.route("/points/history")
+class PointsHistory(MethodView):
+    @login_required
+    @bp.arguments(HistoryQueryArgs, location="query")
+    @bp.response(200, PointsHistoryResponseSchema)
+    def get(self, args):
+        """Paginated ledger for the current user (cursor by ledger id)."""
+        return services.get_points_history(
+            current_user.id, cursor=args.get("cursor"), limit=args.get("limit", 20)
+        )
+
+
+@bp.route("/leaderboard")
+class Leaderboard(MethodView):
+    @login_required
+    @bp.arguments(LeaderboardQueryArgs, location="query")
+    @bp.response(200, LeaderboardResponseSchema)
+    def get(self, args):
+        """Ranked list for a scope/period with the current user's row pinned."""
+        return services.get_leaderboard(
+            scope=args["scope"],
+            period=args["period"],
+            limit=args.get("limit", 50),
+            cursor=args.get("cursor"),
+            user_id=current_user.id,
+        )
+
+
+@bp.route("/badges")
+class BadgeCatalog(MethodView):
+    @bp.response(200, BadgeCatalogResponseSchema)
+    def get(self):
+        """Full active badge catalog."""
+        return {"items": services.get_badge_catalog()}
+
+
+@bp.route("/tiers")
+class Tiers(MethodView):
+    @bp.response(200, TierConfigSchema(many=True))
+    def get(self):
+        """Tier configuration for client-side display."""
+        return services.get_tiers()

--- a/app/gamification/schemas.py
+++ b/app/gamification/schemas.py
@@ -1,0 +1,145 @@
+"""Marshmallow schemas for the gamification REST contract (spec §5.5).
+
+Responses are built as plain dicts in services.py; these schemas shape the
+OpenAPI output and serialise datetimes.
+"""
+
+from marshmallow import Schema, fields, validate
+
+from .constants import LB_SCOPES, LB_PERIODS
+
+
+# --- Shared -------------------------------------------------------------------
+class TierSchema(Schema):
+    key = fields.Str()
+    name = fields.Str()
+    stars = fields.Int()
+    color_hex = fields.Str()
+    progress_to_next = fields.Float()
+    points_to_next_tier = fields.Int()
+
+
+class WeeklyRankSchema(Schema):
+    scope = fields.Str()
+    rank = fields.Int()
+    out_of = fields.Int()
+
+
+class BadgeSchema(Schema):
+    slug = fields.Str()
+    name = fields.Str()
+    description = fields.Str(allow_none=True)
+    icon_url = fields.Str(allow_none=True)
+    category = fields.Str(allow_none=True)
+    audience = fields.Str()
+    priority = fields.Int()
+
+
+# --- GET /me ------------------------------------------------------------------
+class GamMeSchema(Schema):
+    user_id = fields.Str()
+    lifetime_points = fields.Int()
+    available_points = fields.Int()
+    weekly_points = fields.Int()
+    tier = fields.Nested(TierSchema)
+    badges_earned = fields.Int()
+    badges_total = fields.Int()
+    weekly_rank = fields.Nested(WeeklyRankSchema, allow_none=True)
+    opt_out_leaderboard = fields.Bool()
+
+
+# --- GET /users/{id}/profile --------------------------------------------------
+class PublicProfileSchema(Schema):
+    user_id = fields.Str()
+    lifetime_points = fields.Int()
+    tier = fields.Nested(TierSchema)
+    badges = fields.List(fields.Nested(BadgeSchema))
+
+
+# --- GET /users/{id}/badges ---------------------------------------------------
+class UserBadgeSchema(BadgeSchema):
+    earned = fields.Bool()
+    awarded_at = fields.DateTime(allow_none=True)
+    progress = fields.Float()
+
+
+class UserBadgesResponseSchema(Schema):
+    items = fields.List(fields.Nested(UserBadgeSchema))
+
+
+# --- GET /points/history ------------------------------------------------------
+class PointsHistoryItemSchema(Schema):
+    id = fields.Int()
+    delta = fields.Int()
+    reason = fields.Str()
+    ref_type = fields.Str(allow_none=True)
+    ref_id = fields.Str(allow_none=True)
+    balance_after = fields.Int()
+    created_at = fields.DateTime()
+
+
+class PointsHistoryResponseSchema(Schema):
+    items = fields.List(fields.Nested(PointsHistoryItemSchema))
+    next_cursor = fields.Int(allow_none=True)
+
+
+class HistoryQueryArgs(Schema):
+    cursor = fields.Int(load_default=None, allow_none=True)
+    limit = fields.Int(load_default=20, validate=validate.Range(min=1, max=100))
+
+
+# --- GET /leaderboard ---------------------------------------------------------
+class LeaderboardRowSchema(Schema):
+    rank = fields.Int()
+    user_id = fields.Str()
+    points = fields.Int()
+    username = fields.Str(allow_none=True)
+    profile_picture = fields.Str(allow_none=True)
+    tier = fields.Str(allow_none=True)
+    stars = fields.Int(allow_none=True)
+
+
+class LeaderboardRankSchema(Schema):
+    scope = fields.Str()
+    period = fields.Str()
+    rank = fields.Int()
+    points = fields.Int()
+    out_of = fields.Int()
+
+
+class LeaderboardResponseSchema(Schema):
+    scope = fields.Str()
+    period = fields.Str()
+    items = fields.List(fields.Nested(LeaderboardRowSchema))
+    next_cursor = fields.Int(allow_none=True)
+    your_rank = fields.Nested(LeaderboardRankSchema, allow_none=True)
+
+
+class LeaderboardQueryArgs(Schema):
+    scope = fields.Str(load_default="global", validate=validate.OneOf(LB_SCOPES))
+    period = fields.Str(load_default="weekly", validate=validate.OneOf(LB_PERIODS))
+    limit = fields.Int(load_default=50, validate=validate.Range(min=1, max=100))
+    cursor = fields.Int(load_default=None, allow_none=True)
+
+
+# --- GET /tiers ---------------------------------------------------------------
+class TierConfigSchema(Schema):
+    tier = fields.Str()
+    name = fields.Str()
+    min_lifetime_points = fields.Int()
+    color_hex = fields.Str()
+    star_count = fields.Int()
+
+
+# --- GET /badges --------------------------------------------------------------
+class BadgeCatalogResponseSchema(Schema):
+    items = fields.List(fields.Nested(BadgeSchema))
+
+
+# --- PATCH /me/preferences ----------------------------------------------------
+class PreferencesUpdateSchema(Schema):
+    opt_out_leaderboard = fields.Bool(load_default=None, allow_none=True)
+
+
+class PreferencesResponseSchema(Schema):
+    opt_out_leaderboard = fields.Bool()

--- a/app/gamification/services.py
+++ b/app/gamification/services.py
@@ -1,0 +1,773 @@
+"""Gamification business logic: award points, maintain stats, evaluate badges,
+and build the read models the API returns.
+
+Coupling is one-directional: this module reads from existing tables (orders,
+posts, reviews) to compute badge stats, but existing code never imports from
+here — it only emits domain signals that events.py listens to.
+"""
+
+import json
+import logging
+from datetime import datetime, timedelta
+
+from sqlalchemy.exc import IntegrityError
+
+from external.database import db
+from external.redis import redis_client
+from app.libs.session import session_scope
+
+from . import leaderboard, tier_engine, badge_engine
+from .constants import (
+    POINT_VALUES,
+    DAILY_CAPS,
+    DEFAULT_TIER_KEY,
+    TIER_SEED,
+    GAMIFICATION_LAUNCH_DATE,
+    EARLY_BIRD_WINDOW_DAYS,
+    ratelimit_key,
+    stats_cache_key,
+    STATS_CACHE_TTL_SECONDS,
+    LB_SCOPE_GLOBAL,
+)
+from .models import (
+    PointsLedger,
+    UserStats,
+    SellerStats,
+    Badge,
+    UserBadge,
+    TierConfig,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# --------------------------------------------------------------------------- #
+# Tier config cache
+# --------------------------------------------------------------------------- #
+_tier_cache = {"rows": None, "ts": 0.0}
+_TIER_CACHE_TTL = 300
+
+
+def _tier_rows():
+    now = datetime.utcnow().timestamp()
+    if _tier_cache["rows"] and now - _tier_cache["ts"] < _TIER_CACHE_TTL:
+        return _tier_cache["rows"]
+    try:
+        with session_scope() as session:
+            rows = [
+                {
+                    "tier": t.tier,
+                    "name": t.name,
+                    "star_count": t.star_count,
+                    "min_lifetime_points": t.min_lifetime_points,
+                    "color_hex": t.color_hex,
+                }
+                for t in session.query(TierConfig).all()
+            ]
+        if not rows:
+            rows = list(TIER_SEED)
+    except Exception as e:  # pragma: no cover - fall back to seed
+        logger.warning(f"tier config load failed, using seed: {e}")
+        rows = list(TIER_SEED)
+    _tier_cache["rows"] = rows
+    _tier_cache["ts"] = now
+    return rows
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+def _today_str() -> str:
+    return datetime.utcnow().strftime("%Y%m%d")
+
+
+def _get_or_create_stats(session, user_id: str) -> UserStats:
+    stats = (
+        session.query(UserStats).filter_by(user_id=user_id).with_for_update().first()
+    )
+    if stats is None:
+        stats = UserStats(
+            user_id=user_id,
+            lifetime_points=0,
+            available_points=0,
+            weekly_points=0,
+            weekly_period=leaderboard.current_week_key(),
+            current_tier=DEFAULT_TIER_KEY,
+        )
+        session.add(stats)
+        session.flush()
+    return stats
+
+
+def _user_roles(session, user_id: str):
+    """(is_buyer, is_seller) for leaderboard scope routing."""
+    from app.users.models import User
+
+    user = session.query(User).get(user_id)
+    if not user:
+        return (False, False)
+    return (bool(user.is_buyer), bool(user.is_seller))
+
+
+def _within_daily_cap(reason: str, user_id: str) -> bool:
+    cap = DAILY_CAPS.get(reason)
+    if cap is None:
+        return True
+    try:
+        key = ratelimit_key(reason, user_id, _today_str())
+        count = redis_client.incr(key)
+        if count == 1:
+            redis_client.expire(key, 60 * 60 * 48)  # 2 days, covers TZ edges
+        return count <= cap
+    except Exception:
+        # If Redis is unavailable, fail open (award) — better than losing points.
+        return True
+
+
+def _invalidate_stats_cache(user_id: str) -> None:
+    try:
+        redis_client.delete(stats_cache_key(user_id))
+    except Exception:
+        pass
+
+
+def _emit(user_id: str, event: str, data: dict) -> None:
+    try:
+        from main.sockets import emit_to_user
+
+        emit_to_user(user_id, event, data, namespace="/notification")
+    except Exception as e:  # pragma: no cover - realtime best-effort
+        logger.debug(f"gamification emit {event} failed for {user_id}: {e}")
+
+
+# --------------------------------------------------------------------------- #
+# Core: award / reverse points
+# --------------------------------------------------------------------------- #
+def award_points(
+    user_id, delta, reason, ref_type=None, ref_id=None, emit=True, enforce_cap=True
+):
+    """Atomically write a ledger row, update running totals, recompute tier, then
+    (post-commit) update Redis and emit realtime events.
+
+    Idempotent: a duplicate (user_id, reason, ref_type, ref_id) is a no-op,
+    guarded both by a pre-check and by the ledger's unique partial index.
+    Returns a small result dict, or None if skipped (duplicate or capped).
+    """
+    if not user_id or delta == 0:
+        return None
+
+    ref_id_s = None if ref_id is None else str(ref_id)
+
+    # Daily anti-abuse cap (only for positive, capped reasons).
+    if enforce_cap and delta > 0 and reason in DAILY_CAPS:
+        if not _within_daily_cap(reason, user_id):
+            return None
+
+    result = None
+    try:
+        with session_scope() as session:
+            # Short-circuit idempotency check.
+            if ref_id_s is not None:
+                dup = (
+                    session.query(PointsLedger.id)
+                    .filter_by(
+                        user_id=user_id,
+                        reason=reason,
+                        ref_type=ref_type,
+                        ref_id=ref_id_s,
+                    )
+                    .first()
+                )
+                if dup:
+                    return None
+
+            stats = _get_or_create_stats(session, user_id)
+
+            # Weekly rollover.
+            wk = leaderboard.current_week_key()
+            if stats.weekly_period != wk:
+                stats.weekly_period = wk
+                stats.weekly_points = 0
+
+            stats.lifetime_points = (stats.lifetime_points or 0) + delta
+            stats.available_points = (stats.available_points or 0) + delta
+            stats.weekly_points = (stats.weekly_points or 0) + delta
+
+            old_tier = stats.current_tier
+            new_tier = tier_engine.tier_key_for(stats.lifetime_points, _tier_rows())
+            stats.current_tier = new_tier
+
+            ledger = PointsLedger(
+                user_id=user_id,
+                delta=delta,
+                reason=reason,
+                ref_type=ref_type,
+                ref_id=ref_id_s,
+                balance_after=stats.available_points,
+            )
+            session.add(ledger)
+            try:
+                session.flush()
+            except IntegrityError:
+                session.rollback()  # concurrent duplicate lost the race
+                return None
+
+            is_buyer, is_seller = _user_roles(session, user_id)
+            result = {
+                "delta": delta,
+                "reason": reason,
+                "new_balance": stats.available_points,
+                "lifetime_points": stats.lifetime_points,
+                "weekly_points": stats.weekly_points,
+                "old_tier": old_tier,
+                "new_tier": new_tier,
+                "is_buyer": is_buyer,
+                "is_seller": is_seller,
+                "star_count": _stars_for(new_tier),
+            }
+    except IntegrityError:
+        return None
+    except Exception as e:
+        logger.error(f"award_points failed ({reason}, {user_id}): {e}")
+        return None
+
+    if not result:
+        return None
+
+    # Post-commit: Redis leaderboard + cache invalidation + realtime.
+    leaderboard.apply_award(
+        user_id,
+        delta,
+        result["lifetime_points"],
+        result["weekly_points"],
+        result["is_buyer"],
+        result["is_seller"],
+    )
+    _invalidate_stats_cache(user_id)
+
+    if emit:
+        _emit(
+            user_id,
+            "gamification:points_awarded",
+            {
+                "delta": delta,
+                "reason": reason,
+                "new_balance": result["new_balance"],
+            },
+        )
+        if result["new_tier"] != result["old_tier"]:
+            _emit(
+                user_id,
+                "gamification:tier_changed",
+                {
+                    "old_tier": result["old_tier"],
+                    "new_tier": result["new_tier"],
+                    "stars": result["star_count"],
+                },
+            )
+    return result
+
+
+def award_by_reason(user_id, reason, ref_type=None, ref_id=None, **kw):
+    """Award the configured point value for a reason key (Appendix A)."""
+    delta = POINT_VALUES.get(reason)
+    if delta is None:
+        logger.warning(f"award_by_reason: unknown reason '{reason}'")
+        return None
+    return award_points(user_id, delta, reason, ref_type=ref_type, ref_id=ref_id, **kw)
+
+
+def reverse_award(user_id, reason, ref_type, ref_id, reversal_reason):
+    """Claw back a prior award with a negative ledger entry (spec §4.1).
+
+    Looks up the original positive award(s) for (reason, ref) and writes the
+    negated total. Idempotent on the reversal ref.
+    """
+    if not user_id:
+        return None
+    ref_id_s = None if ref_id is None else str(ref_id)
+    with session_scope() as session:
+        original = (
+            session.query(PointsLedger)
+            .filter_by(
+                user_id=user_id, reason=reason, ref_type=ref_type, ref_id=ref_id_s
+            )
+            .first()
+        )
+        if not original or original.delta <= 0:
+            return None
+        already = (
+            session.query(PointsLedger.id)
+            .filter_by(
+                user_id=user_id,
+                reason=reversal_reason,
+                ref_type=ref_type,
+                ref_id=ref_id_s,
+            )
+            .first()
+        )
+        if already:
+            return None
+    return award_points(
+        user_id,
+        -original.delta,
+        reversal_reason,
+        ref_type=ref_type,
+        ref_id=ref_id,
+        enforce_cap=False,
+    )
+
+
+def _stars_for(tier_key: str) -> int:
+    for row in _tier_rows():
+        if row["tier"] == tier_key:
+            return row["star_count"]
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# Seller stats maintenance
+# --------------------------------------------------------------------------- #
+def _get_or_create_seller_stats(session, user_id: str) -> SellerStats:
+    ss = session.query(SellerStats).filter_by(user_id=user_id).with_for_update().first()
+    if ss is None:
+        ss = SellerStats(user_id=user_id)
+        session.add(ss)
+        session.flush()
+    return ss
+
+
+def record_sale(user_id: str, ship_hours: float = None, on_time: bool = None) -> None:
+    """Increment a seller's completed-sales aggregates (order.completed)."""
+    with session_scope() as session:
+        ss = _get_or_create_seller_stats(session, user_id)
+        ss.total_sales = (ss.total_sales or 0) + 1
+        if ship_hours is not None:
+            ss.ship_count = (ss.ship_count or 0) + 1
+            ss.ship_hours_sum = (ss.ship_hours_sum or 0.0) + float(ship_hours)
+            if on_time:
+                ss.on_time_count = (ss.on_time_count or 0) + 1
+            ss.avg_ship_hours = ss.ship_hours_sum / ss.ship_count
+            ss.on_time_pct = (ss.on_time_count or 0) / ss.ship_count * 100.0
+
+
+def record_review(user_id: str, rating: float) -> None:
+    """Fold a new review rating into a seller's average (review.created)."""
+    with session_scope() as session:
+        ss = _get_or_create_seller_stats(session, user_id)
+        ss.review_count = (ss.review_count or 0) + 1
+        ss.rating_sum = (ss.rating_sum or 0.0) + float(rating)
+        ss.avg_rating = round(ss.rating_sum / ss.review_count, 3)
+
+
+# --------------------------------------------------------------------------- #
+# Badge stats + evaluation
+# --------------------------------------------------------------------------- #
+def get_badge_stats(user_id: str) -> dict:
+    """Assemble the flat stats dict badge_engine evaluates against.
+
+    Seller aggregates come from gam_seller_stats; buyer/community stats are
+    computed on demand. Each cross-module lookup is guarded so a schema quirk
+    degrades a single stat rather than breaking evaluation.
+    """
+    stats = {
+        "total_sales": 0,
+        "avg_rating": 0.0,
+        "avg_ship_hours": None,
+        "on_time_pct": 0.0,
+        "review_count": 0,
+        "is_verified_seller": 0,
+        "is_early_member": 0,
+        "completed_purchases": 0,
+        "max_same_seller_purchases": 0,
+        "total_reactions_received": 0,
+        "best_post_driven_orders": 0,
+    }
+    with session_scope() as session:
+        ss = session.query(SellerStats).filter_by(user_id=user_id).first()
+        if ss:
+            stats.update(
+                {
+                    "total_sales": ss.total_sales or 0,
+                    "avg_rating": ss.avg_rating or 0.0,
+                    "avg_ship_hours": ss.avg_ship_hours,
+                    "on_time_pct": ss.on_time_pct or 0.0,
+                    "review_count": ss.review_count or 0,
+                }
+            )
+
+        from app.users.models import User
+
+        user = session.query(User).get(user_id)
+        if user:
+            # Verified seller.
+            try:
+                from app.users.models import SellerVerificationStatus
+
+                sa = user.seller_account
+                if sa and sa.verification_status == SellerVerificationStatus.VERIFIED:
+                    stats["is_verified_seller"] = 1
+            except Exception:
+                pass
+            # Early bird.
+            try:
+                launch = datetime.strptime(GAMIFICATION_LAUNCH_DATE, "%Y-%m-%d")
+                cutoff = launch + timedelta(days=EARLY_BIRD_WINDOW_DAYS)
+                if user.created_at and user.created_at <= cutoff:
+                    stats["is_early_member"] = 1
+            except Exception:
+                pass
+            # Buyer purchase stats.
+            try:
+                if user.buyer_account:
+                    _fill_buyer_stats(session, user.buyer_account.id, stats)
+            except Exception as e:
+                logger.debug(f"buyer stats skipped for {user_id}: {e}")
+            # Community reactions (likes across the user's posts).
+            try:
+                stats["total_reactions_received"] = _count_post_reactions(
+                    session, user_id
+                )
+            except Exception as e:
+                logger.debug(f"reaction stats skipped for {user_id}: {e}")
+    return stats
+
+
+def _fill_buyer_stats(session, buyer_id: int, stats: dict) -> None:
+    from sqlalchemy import func
+    from app.orders.models import Order, OrderStatus
+
+    completed = (
+        session.query(func.count(Order.id))
+        .filter(Order.buyer_id == buyer_id, Order.status == OrderStatus.DELIVERED)
+        .scalar()
+    ) or 0
+    stats["completed_purchases"] = int(completed)
+
+    # Max purchases from a single seller (repeat_customer). Counts distinct
+    # delivered orders per seller via order items.
+    from app.orders.models import OrderItem
+
+    rows = (
+        session.query(
+            OrderItem.seller_id, func.count(func.distinct(OrderItem.order_id))
+        )
+        .join(Order, Order.id == OrderItem.order_id)
+        .filter(Order.buyer_id == buyer_id, Order.status == OrderStatus.DELIVERED)
+        .group_by(OrderItem.seller_id)
+        .all()
+    )
+    stats["max_same_seller_purchases"] = max((c for _, c in rows), default=0)
+
+
+def _count_post_reactions(session, user_id: str) -> int:
+    from sqlalchemy import func
+    from app.socials.models import Post, PostLike
+
+    count = (
+        session.query(func.count(PostLike.id))
+        .join(Post, Post.id == PostLike.post_id)
+        .filter(Post.user_id == user_id)
+        .scalar()
+    )
+    return int(count or 0)
+
+
+def evaluate_badges_for(user_id: str, trigger: str) -> list:
+    """Re-evaluate every active badge whose trigger includes `trigger`.
+
+    Awards any newly-satisfied badge (idempotent on the unique (user, badge)
+    constraint) and emits badge_earned. Returns the list of newly-awarded slugs.
+    """
+    if not user_id:
+        return []
+
+    stats = get_badge_stats(user_id)
+    newly = []
+    with session_scope() as session:
+        candidates = session.query(Badge).filter(Badge.is_active.is_(True)).all()
+        held = {
+            ub.badge_id
+            for ub in session.query(UserBadge.badge_id).filter_by(user_id=user_id).all()
+        }
+        for badge in candidates:
+            criteria = badge.criteria_json or {}
+            if trigger not in badge_engine.triggers(criteria):
+                continue
+            if badge.id in held:
+                continue
+            if not badge_engine.evaluate(criteria, stats):
+                continue
+            ub = UserBadge(
+                user_id=user_id, badge_id=badge.id, progress_json={"met": True}
+            )
+            session.add(ub)
+            try:
+                session.flush()
+            except IntegrityError:
+                session.rollback()
+                continue
+            newly.append(badge)
+
+    for badge in newly:
+        _emit(
+            user_id,
+            "gamification:badge_earned",
+            {
+                "badge": {
+                    "slug": badge.slug,
+                    "name": badge.name,
+                    "icon_url": badge.icon_url,
+                    "description": badge.description,
+                }
+            },
+        )
+    if newly:
+        _invalidate_stats_cache(user_id)
+    return [b.slug for b in newly]
+
+
+# --------------------------------------------------------------------------- #
+# Read models (for routes)
+# --------------------------------------------------------------------------- #
+def get_me(user_id: str) -> dict:
+    with session_scope() as session:
+        stats = session.query(UserStats).filter_by(user_id=user_id).first()
+        lifetime = stats.lifetime_points if stats else 0
+        available = stats.available_points if stats else 0
+        weekly = stats.weekly_points if stats else 0
+        earned = session.query(UserBadge).filter_by(user_id=user_id).count()
+        total_badges = session.query(Badge).filter(Badge.is_active.is_(True)).count()
+        opt_out = _get_opt_out(session, user_id)
+
+    prog = tier_engine.tier_progress(lifetime, _tier_rows())
+    rank = leaderboard.get_user_rank(LB_SCOPE_GLOBAL, "weekly", user_id)
+
+    return {
+        "user_id": user_id,
+        "lifetime_points": lifetime,
+        "available_points": available,
+        "weekly_points": weekly,
+        "tier": _tier_payload(prog),
+        "badges_earned": earned,
+        "badges_total": total_badges,
+        "weekly_rank": (
+            {"scope": "global", "rank": rank["rank"], "out_of": rank["out_of"]}
+            if rank
+            else None
+        ),
+        "opt_out_leaderboard": opt_out,
+    }
+
+
+def get_public_profile(user_id: str) -> dict:
+    with session_scope() as session:
+        stats = session.query(UserStats).filter_by(user_id=user_id).first()
+        lifetime = stats.lifetime_points if stats else 0
+        badges = _user_badges_payload(session, user_id)
+    prog = tier_engine.tier_progress(lifetime, _tier_rows())
+    return {
+        "user_id": user_id,
+        "lifetime_points": lifetime,
+        "tier": _tier_payload(prog),
+        "badges": badges,
+    }
+
+
+def get_points_history(user_id: str, cursor: int = None, limit: int = 20) -> dict:
+    limit = max(1, min(limit, 100))
+    with session_scope() as session:
+        q = session.query(PointsLedger).filter_by(user_id=user_id)
+        if cursor:
+            q = q.filter(PointsLedger.id < cursor)
+        rows = q.order_by(PointsLedger.id.desc()).limit(limit + 1).all()
+    has_more = len(rows) > limit
+    rows = rows[:limit]
+    return {
+        "items": [
+            {
+                "id": r.id,
+                "delta": r.delta,
+                "reason": r.reason,
+                "ref_type": r.ref_type,
+                "ref_id": r.ref_id,
+                "balance_after": r.balance_after,
+                "created_at": r.created_at,
+            }
+            for r in rows
+        ],
+        "next_cursor": rows[-1].id if (has_more and rows) else None,
+    }
+
+
+def get_badge_catalog() -> list:
+    with session_scope() as session:
+        badges = (
+            session.query(Badge)
+            .filter(Badge.is_active.is_(True))
+            .order_by(Badge.priority.desc())
+            .all()
+        )
+        return [_badge_payload(b) for b in badges]
+
+
+def get_user_badges(user_id: str) -> dict:
+    stats = get_badge_stats(user_id)
+    with session_scope() as session:
+        active = (
+            session.query(Badge)
+            .filter(Badge.is_active.is_(True))
+            .order_by(Badge.priority.desc())
+            .all()
+        )
+        held = {
+            ub.badge_id: ub
+            for ub in session.query(UserBadge).filter_by(user_id=user_id).all()
+        }
+        items = []
+        for b in active:
+            ub = held.get(b.id)
+            items.append(
+                {
+                    **_badge_payload(b),
+                    "earned": ub is not None,
+                    "awarded_at": ub.awarded_at if ub else None,
+                    "progress": (
+                        1.0
+                        if ub
+                        else badge_engine.progress(b.criteria_json or {}, stats)
+                    ),
+                }
+            )
+    return {"items": items}
+
+
+def get_tiers() -> list:
+    return _tier_rows()
+
+
+def get_leaderboard(
+    scope: str, period: str, limit: int = 50, cursor: int = None, user_id: str = None
+) -> dict:
+    offset = int(cursor or 0)
+    limit = max(1, min(limit, 100))
+    rows = leaderboard.get_page(scope, period, limit=limit, offset=offset)
+
+    # Hydrate light user identity for display.
+    ids = [r["user_id"] for r in rows]
+    identities = _identities_for(ids)
+    for r in rows:
+        r.update(identities.get(r["user_id"], {}))
+
+    your_rank = None
+    if user_id:
+        your_rank = leaderboard.get_user_rank(scope, period, user_id)
+
+    return {
+        "scope": scope,
+        "period": period,
+        "items": rows,
+        "next_cursor": offset + limit if len(rows) == limit else None,
+        "your_rank": your_rank,
+    }
+
+
+def set_preferences(user_id: str, opt_out_leaderboard: bool = None) -> dict:
+    with session_scope() as session:
+        if opt_out_leaderboard is not None:
+            _set_opt_out(session, user_id, opt_out_leaderboard)
+    if opt_out_leaderboard is not None:
+        leaderboard.set_opt_out(user_id, opt_out_leaderboard)
+    return {"opt_out_leaderboard": _get_opt_out_uncached(user_id)}
+
+
+# --------------------------------------------------------------------------- #
+# Preference storage (Redis-backed flag; no schema change needed for MVP)
+# --------------------------------------------------------------------------- #
+_OPTOUT_FLAG = "gam:pref:optout"
+
+
+def _set_opt_out(session, user_id: str, value: bool) -> None:
+    try:
+        if value:
+            redis_client.sadd(_OPTOUT_FLAG, user_id)
+        else:
+            redis_client.srem(_OPTOUT_FLAG, user_id)
+    except Exception:
+        pass
+
+
+def _get_opt_out(session, user_id: str) -> bool:
+    return _get_opt_out_uncached(user_id)
+
+
+def _get_opt_out_uncached(user_id: str) -> bool:
+    try:
+        return bool(redis_client.client.sismember(_OPTOUT_FLAG, user_id))
+    except Exception:
+        return False
+
+
+# --------------------------------------------------------------------------- #
+# Payload helpers
+# --------------------------------------------------------------------------- #
+def _tier_payload(prog: dict) -> dict:
+    cur = prog["current"]
+    return {
+        "key": cur["tier"],
+        "name": cur["name"],
+        "stars": cur["star_count"],
+        "color_hex": cur["color_hex"],
+        "progress_to_next": prog["progress_to_next"],
+        "points_to_next_tier": prog["points_to_next_tier"],
+    }
+
+
+def _badge_payload(b: Badge) -> dict:
+    return {
+        "slug": b.slug,
+        "name": b.name,
+        "description": b.description,
+        "icon_url": b.icon_url,
+        "category": b.category,
+        "audience": b.audience,
+        "priority": b.priority,
+    }
+
+
+def _user_badges_payload(session, user_id: str) -> list:
+    rows = (
+        session.query(UserBadge, Badge)
+        .join(Badge, Badge.id == UserBadge.badge_id)
+        .filter(UserBadge.user_id == user_id)
+        .order_by(Badge.priority.desc())
+        .all()
+    )
+    return [{**_badge_payload(b), "awarded_at": ub.awarded_at} for ub, b in rows]
+
+
+def _identities_for(user_ids: list) -> dict:
+    if not user_ids:
+        return {}
+    out = {}
+    try:
+        with session_scope() as session:
+            from app.users.models import User
+
+            users = session.query(User).filter(User.id.in_(user_ids)).all()
+            stats = {
+                s.user_id: s.current_tier
+                for s in session.query(UserStats)
+                .filter(UserStats.user_id.in_(user_ids))
+                .all()
+            }
+            for u in users:
+                out[u.id] = {
+                    "username": u.username,
+                    "profile_picture": u.profile_picture,
+                    "tier": stats.get(u.id, DEFAULT_TIER_KEY),
+                    "stars": _stars_for(stats.get(u.id, DEFAULT_TIER_KEY)),
+                }
+    except Exception as e:
+        logger.debug(f"identity hydrate failed: {e}")
+    return out

--- a/app/gamification/tier_engine.py
+++ b/app/gamification/tier_engine.py
@@ -1,0 +1,69 @@
+"""Pure functions mapping lifetime points to a tier (spec §4.2).
+
+No database or Redis access here so these are trivially unit-testable. Callers
+pass in the tier rows (from gam_tier_config, cached) as a list of dicts:
+    {"tier", "name", "star_count", "min_lifetime_points", "color_hex"}
+"""
+
+from typing import List, Dict, Optional
+
+from .constants import TIER_SEED, DEFAULT_TIER_KEY
+
+
+def _sorted_rows(tier_rows: List[Dict]) -> List[Dict]:
+    return sorted(tier_rows or TIER_SEED, key=lambda r: r["min_lifetime_points"])
+
+
+def compute_tier(lifetime_points: int, tier_rows: List[Dict] = None) -> Dict:
+    """Return the highest tier whose threshold is <= lifetime_points."""
+    rows = _sorted_rows(tier_rows)
+    current = rows[0]
+    for row in rows:
+        if lifetime_points >= row["min_lifetime_points"]:
+            current = row
+        else:
+            break
+    return current
+
+
+def next_tier(lifetime_points: int, tier_rows: List[Dict] = None) -> Optional[Dict]:
+    """Return the next tier above the current one, or None at the top tier."""
+    rows = _sorted_rows(tier_rows)
+    for row in rows:
+        if row["min_lifetime_points"] > lifetime_points:
+            return row
+    return None
+
+
+def tier_progress(lifetime_points: int, tier_rows: List[Dict] = None) -> Dict:
+    """Full progression view for the profile header.
+
+    Returns the current tier row plus progress_to_next (0..1) and
+    points_to_next_tier. At the top tier progress is 1.0 and points_to_next is 0.
+    """
+    rows = _sorted_rows(tier_rows)
+    current = compute_tier(lifetime_points, rows)
+    nxt = next_tier(lifetime_points, rows)
+
+    if nxt is None:
+        return {
+            "current": current,
+            "next": None,
+            "progress_to_next": 1.0,
+            "points_to_next_tier": 0,
+        }
+
+    span = nxt["min_lifetime_points"] - current["min_lifetime_points"]
+    gained = lifetime_points - current["min_lifetime_points"]
+    progress = 0.0 if span <= 0 else max(0.0, min(1.0, gained / span))
+    return {
+        "current": current,
+        "next": nxt,
+        "progress_to_next": round(progress, 4),
+        "points_to_next_tier": max(0, nxt["min_lifetime_points"] - lifetime_points),
+    }
+
+
+def tier_key_for(lifetime_points: int, tier_rows: List[Dict] = None) -> str:
+    row = compute_tier(lifetime_points, tier_rows)
+    return row.get("tier", DEFAULT_TIER_KEY)

--- a/app/notifications/sockets.py
+++ b/app/notifications/sockets.py
@@ -72,6 +72,22 @@ class NotificationNamespace(Namespace):
         except Exception as e:
             logger.error(f"Notification disconnection error: {e}")
 
+    def on_register(self, data):
+        """Join the caller to their personal room so per-user server pushes
+        (notifications and gamification events) reach this socket. The client
+        emits this right after connecting with its user id."""
+        from main.sockets import SocketManager
+
+        try:
+            user_id = (data or {}).get("user_id")
+            if not user_id:
+                return
+            join_room(f"user_{user_id}")
+            SocketManager.mark_user_online(user_id)
+            emit("registered", {"user_id": user_id})
+        except Exception as e:
+            logger.error(f"Notification register error: {e}")
+
     def on_mark_as_read(self, data):
         """Handle mark as read request via socket with validation"""
         try:

--- a/app/orders/services.py
+++ b/app/orders/services.py
@@ -38,7 +38,6 @@ from app.orders.shipping import (
     shipping_address_to_model_kwargs,
 )
 
-
 logger = logging.getLogger(__name__)
 
 BUYER_CANCELLABLE_STATUSES = {
@@ -220,7 +219,36 @@ class OrderService:
             except Exception as e:
                 logger.warning(f"Failed to queue order_status_changed event: {e}")
 
-            return order
+        # Post-commit: gamification points (award on delivery, reverse on
+        # cancel/return of a previously-delivered order).
+        if new_status == OrderStatus.DELIVERED and old_status != OrderStatus.DELIVERED:
+            OrderService._emit_gam_order_completed(order_id)
+        elif (
+            new_status
+            in (OrderStatus.CANCELLED, OrderStatus.RETURNED, OrderStatus.FAILED)
+            and old_status == OrderStatus.DELIVERED
+        ):
+            OrderService._emit_gam_order_reversed(order_id)
+
+        return order
+
+    @staticmethod
+    def _emit_gam_order_completed(order_id):
+        try:
+            from app.signals import order_completed
+
+            order_completed.send("orders", order_id=order_id)
+        except Exception as e:  # never let gamification break order flow
+            logger.warning(f"gamification order_completed emit failed: {e}")
+
+    @staticmethod
+    def _emit_gam_order_reversed(order_id):
+        try:
+            from app.signals import order_reversed
+
+            order_reversed.send("orders", order_id=order_id)
+        except Exception as e:
+            logger.warning(f"gamification order_reversed emit failed: {e}")
 
     @staticmethod
     def _get_completed_payment_amount(order: Order) -> float:
@@ -350,9 +378,9 @@ class OrderService:
                 {
                     "status": "created",
                     "label": "Order placed",
-                    "timestamp": order.created_at.isoformat()
-                    if order.created_at
-                    else None,
+                    "timestamp": (
+                        order.created_at.isoformat() if order.created_at else None
+                    ),
                 }
             ]
             if latest_payment and latest_payment.paid_at:
@@ -376,9 +404,9 @@ class OrderService:
                     {
                         "status": "delivered",
                         "label": "Delivered",
-                        "timestamp": order.updated_at.isoformat()
-                        if order.updated_at
-                        else None,
+                        "timestamp": (
+                            order.updated_at.isoformat() if order.updated_at else None
+                        ),
                     }
                 )
 
@@ -388,12 +416,16 @@ class OrderService:
                 delivery_info = {
                     "assignment_id": assignment.assignment_id,
                     "status": assignment.status.value,
-                    "logistical_status": assignment.logistical_status.value
-                    if assignment.logistical_status
-                    else None,
-                    "assigned_at": assignment.assigned_at.isoformat()
-                    if assignment.assigned_at
-                    else None,
+                    "logistical_status": (
+                        assignment.logistical_status.value
+                        if assignment.logistical_status
+                        else None
+                    ),
+                    "assigned_at": (
+                        assignment.assigned_at.isoformat()
+                        if assignment.assigned_at
+                        else None
+                    ),
                 }
 
             return {
@@ -412,20 +444,26 @@ class OrderService:
                     }
                     for item in order.items
                 ],
-                "shipment": {
-                    "carrier": shipment.carrier,
-                    "tracking_number": shipment.tracking_number,
-                    "tracking_url": shipment.tracking_url,
-                    "status": shipment.status,
-                    "shipped_at": shipment.shipped_at.isoformat()
-                    if shipment and shipment.shipped_at
-                    else None,
-                    "delivered_at": shipment.delivered_at.isoformat()
-                    if shipment and shipment.delivered_at
-                    else None,
-                }
-                if shipment
-                else None,
+                "shipment": (
+                    {
+                        "carrier": shipment.carrier,
+                        "tracking_number": shipment.tracking_number,
+                        "tracking_url": shipment.tracking_url,
+                        "status": shipment.status,
+                        "shipped_at": (
+                            shipment.shipped_at.isoformat()
+                            if shipment and shipment.shipped_at
+                            else None
+                        ),
+                        "delivered_at": (
+                            shipment.delivered_at.isoformat()
+                            if shipment and shipment.delivered_at
+                            else None
+                        ),
+                    }
+                    if shipment
+                    else None
+                ),
                 "delivery": delivery_info,
             }
 
@@ -540,6 +578,10 @@ class OrderService:
                 idempotency_key=f"return-refund:{return_id}",
             )
 
+        # Post-commit: claw back any gamification points earned on this order.
+        if order_id:
+            OrderService._emit_gam_order_reversed(order_id)
+
         return order_return
 
     @staticmethod
@@ -638,16 +680,22 @@ class SellerOrderService:
 
             item.status = status
 
+            completed_order_id = None
             if status == OrderItem.Status.DELIVERED:
                 order = session.query(Order).get(item.order_id)
                 if all(i.status == OrderItem.Status.DELIVERED for i in order.items):
                     order.status = OrderStatus.DELIVERED
+                    completed_order_id = order.id
 
                 from app.wallet.services import WalletService
 
                 WalletService.settle_order_item(item)
 
-            return item
+        # Post-commit: award gamification points once the whole order is delivered.
+        if completed_order_id:
+            OrderService._emit_gam_order_completed(completed_order_id)
+
+        return item
 
     @staticmethod
     def get_seller_order_stats(seller_id):

--- a/app/signals.py
+++ b/app/signals.py
@@ -1,0 +1,32 @@
+"""Application-wide domain signals (blinker; already a Flask dependency).
+
+These decouple feature modules: an emitter (e.g. orders) fires a signal after
+its own commit, and any number of listeners (e.g. gamification) react. The
+emitter knows nothing about the listeners, so a feature can be turned off by
+simply not importing its events module.
+
+Emit *after* your own DB commit — listeners open their own transactions.
+"""
+
+from blinker import Namespace
+
+_signals = Namespace()
+
+# Orders
+order_completed = _signals.signal("order-completed")  # kw: order
+order_reversed = _signals.signal("order-reversed")  # kw: order
+
+# Social
+post_created = _signals.signal("post-created")  # kw: post
+post_reaction_added = _signals.signal("post-reaction-added")  # kw: post, reactor_id
+
+# Reviews
+review_created = _signals.signal("review-created")  # kw: review
+
+# Users
+profile_completed = _signals.signal("profile-completed")  # kw: user_id
+referral_first_paid = _signals.signal(
+    "referral-first-paid"
+)  # kw: referrer_id, referee_id
+daily_login = _signals.signal("daily-login")  # kw: user_id
+seller_verified = _signals.signal("seller-verified")  # kw: user_id

--- a/app/socials/services.py
+++ b/app/socials/services.py
@@ -65,6 +65,33 @@ from .constants import POST_STATUS_TRANSITIONS
 logger = logging.getLogger(__name__)
 
 
+class _SignalPost:
+    """Minimal detached carrier for post gamification signals.
+
+    Signals fire post-commit, so we pass a tiny value object with just the
+    fields the listener needs (id, author user_id) rather than a live/detached
+    ORM row that could trigger lazy loads.
+    """
+
+    __slots__ = ("id", "user_id")
+
+    def __init__(self, post_id, user_id):
+        self.id = post_id
+        self.user_id = user_id
+
+
+class _SignalReview:
+    """Minimal detached carrier for review gamification signals."""
+
+    __slots__ = ("id", "user_id", "rating", "product_id")
+
+    def __init__(self, review_id, user_id, rating, product_id):
+        self.id = review_id
+        self.user_id = user_id
+        self.rating = rating
+        self.product_id = product_id
+
+
 class NicheService:
     """Service for managing niche communities with role-based access control"""
 
@@ -983,12 +1010,40 @@ class PostService:
                     {post.id: int(post.created_at.timestamp())},
                 )
 
-                return post
+                post_id = post.id
+
+            # Post-commit: award gamification points to the author.
+            PostService._emit_gam_post_created(post_id, user_id)
+            return post
         except SQLAlchemyError as e:
             logger.error(f"Error creating post: {str(e)}")
             raise ConflictError("Failed to create post")
         except (RedisError, RedisConnectionError) as e:
             logger.warning(f"Redis error while creating post: {str(e)}", exc_info=True)
+
+    @staticmethod
+    def _emit_gam_post_created(post_id, user_id):
+        """Fire the post-created domain signal (gamification listens)."""
+        try:
+            from app.signals import post_created
+
+            post_created.send("socials", post=_SignalPost(post_id, user_id))
+        except Exception as e:  # never let gamification break post creation
+            logger.warning(f"gamification post_created emit failed: {e}")
+
+    @staticmethod
+    def _emit_gam_post_reaction(post_id, author_user_id, reactor_id):
+        """Fire the post-reaction signal for the post author."""
+        try:
+            from app.signals import post_reaction_added
+
+            post_reaction_added.send(
+                "socials",
+                post=_SignalPost(post_id, author_user_id),
+                reactor_id=reactor_id,
+            )
+        except Exception as e:
+            logger.warning(f"gamification post_reaction emit failed: {e}")
 
     @staticmethod
     def get_post(post_id):
@@ -1156,7 +1211,12 @@ class PostService:
                 except Exception as e:
                     logger.warning(f"Failed to queue post_liked event: {e}")
 
-                return like
+                author_id = post.user_id if (post and post.user_id != user_id) else None
+
+            # Post-commit: award reaction points to the post author (capped/day).
+            if author_id:
+                PostService._emit_gam_post_reaction(post_id, author_id, user_id)
+            return like
         except SQLAlchemyError as e:
             logger.error(f"Error liking post: {str(e)}")
             raise ConflictError("Failed to like post")
@@ -1893,7 +1953,22 @@ class ProductSocialService:
                 except Exception as e:
                     logger.warning(f"Failed to queue review_added event: {e}")
 
-                return review
+                review_id = review.id
+                review_rating = data.get("rating")
+
+            # Post-commit: award gamification points to the reviewer and fold the
+            # rating into the seller's aggregate for badge evaluation.
+            try:
+                from app.signals import review_created
+
+                review_created.send(
+                    "socials",
+                    review=_SignalReview(review_id, user_id, review_rating, product_id),
+                )
+            except Exception as e:
+                logger.warning(f"gamification review_created emit failed: {e}")
+
+            return review
         except Exception as e:
             logger.error(f"Error adding review: {str(e)}")
             raise APIError("Failed to add review", 500)

--- a/app/users/routes.py
+++ b/app/users/routes.py
@@ -92,6 +92,13 @@ class UserLogin(MethodView):
             )
             login_user(user)
             user.access_token = generate_auth_token(user.id)
+            # Gamification: first login of the day (idempotent per day).
+            try:
+                from app.signals import daily_login
+
+                daily_login.send("users", user_id=user.id)
+            except Exception as e:
+                logger.warning(f"gamification daily_login emit failed: {e}")
             return user
         except UnverifiedEmailError as e:
             # Return structured payload that frontend can detect easily

--- a/app/users/services.py
+++ b/app/users/services.py
@@ -379,7 +379,37 @@ class UserService:
                 pass
 
             session.commit()
-            return user
+
+        UserService._maybe_emit_profile_completed(user_id)
+        return user
+
+    @staticmethod
+    def _is_profile_complete(user) -> bool:
+        """A profile counts as 'completed' for gamification once the user adds
+        the optional-at-signup fields the app nudges them to fill: a phone
+        number and a non-default profile picture."""
+        if not user:
+            return False
+        has_phone = bool(user.phone_number and str(user.phone_number).strip())
+        pic = user.profile_picture
+        has_photo = bool(pic and pic != "default.jpg")
+        return has_phone and has_photo
+
+    @staticmethod
+    def _maybe_emit_profile_completed(user_id):
+        """Emit the profile.completed signal (idempotent +50) when the profile
+        is complete. Safe to call after any profile update — the underlying
+        award is granted at most once via ref_id=user_id."""
+        try:
+            with session_scope() as session:
+                user = session.query(User).get(user_id)
+                complete = UserService._is_profile_complete(user)
+            if complete:
+                from app.signals import profile_completed
+
+                profile_completed.send("users", user_id=user_id)
+        except Exception as e:
+            logger.warning(f"gamification profile_completed emit failed: {e}")
 
     @staticmethod
     def update_buyer_profile(user_id, data):
@@ -394,7 +424,9 @@ class UserService:
                 buyer.shipping_address = data["shipping_address"]
 
             session.commit()
-            return buyer
+
+        UserService._maybe_emit_profile_completed(user_id)
+        return buyer
 
     @staticmethod
     def update_seller_profile(user_id, data):
@@ -431,7 +463,9 @@ class UserService:
                     session.add(seller_category)
 
             session.commit()
-            return seller
+
+        UserService._maybe_emit_profile_completed(user_id)
+        return seller
 
     @staticmethod
     def list_users(args):
@@ -515,9 +549,9 @@ class UserService:
 
             return {
                 "available": not exists,
-                "message": "Username is already taken"
-                if exists
-                else "Username available",
+                "message": (
+                    "Username is already taken" if exists else "Username available"
+                ),
             }
 
     @staticmethod
@@ -588,6 +622,9 @@ class UserService:
                     raise AuthError("User not found")
                 user.profile_picture = media.get_url()  # Original URL for now
                 session.commit()
+
+            # A photo is often the final step to a complete profile — check now.
+            UserService._maybe_emit_profile_completed(user_id)
 
             return {
                 "success": True,
@@ -876,9 +913,11 @@ class ShopService:
                         "is_active": shop.is_active,
                         "total_rating": shop.total_rating,
                         "total_raters": shop.total_raters,
-                        "average_rating": shop.total_rating / shop.total_raters
-                        if shop.total_raters > 0
-                        else 0,
+                        "average_rating": (
+                            shop.total_rating / shop.total_raters
+                            if shop.total_raters > 0
+                            else 0
+                        ),
                         "user": {
                             "id": shop.user.id,
                             "username": shop.user.username,
@@ -970,9 +1009,11 @@ class ShopService:
                     "is_active": shop.is_active,
                     "total_rating": shop.total_rating,
                     "total_raters": shop.total_raters,
-                    "average_rating": shop.total_rating / shop.total_raters
-                    if shop.total_raters > 0
-                    else 0,
+                    "average_rating": (
+                        shop.total_rating / shop.total_raters
+                        if shop.total_raters > 0
+                        else 0
+                    ),
                     "policies": shop.policies,
                     "user": {
                         "id": shop.user.id,
@@ -1051,9 +1092,11 @@ class ShopService:
                         ],
                         "total_rating": shop.total_rating,
                         "total_raters": shop.total_raters,
-                        "average_rating": shop.total_rating / shop.total_raters
-                        if shop.total_raters > 0
-                        else 0,
+                        "average_rating": (
+                            shop.total_rating / shop.total_raters
+                            if shop.total_raters > 0
+                            else 0
+                        ),
                         "user": {
                             "id": shop.user.id,
                             "username": shop.user.username,
@@ -1113,9 +1156,11 @@ class ShopService:
             media_items.append(
                 {
                     "url": url,
-                    "type": media.media_type.value
-                    if hasattr(media.media_type, "value")
-                    else media.media_type,
+                    "type": (
+                        media.media_type.value
+                        if hasattr(media.media_type, "value")
+                        else media.media_type
+                    ),
                     "alt_text": media.alt_text,
                 }
             )
@@ -1133,9 +1178,11 @@ class ShopService:
             product.images,
             key=lambda img: (
                 not getattr(img, "is_featured", False),
-                getattr(img, "sort_order", 0)
-                if getattr(img, "sort_order", None) is not None
-                else 0,
+                (
+                    getattr(img, "sort_order", 0)
+                    if getattr(img, "sort_order", None) is not None
+                    else 0
+                ),
             ),
         )
 

--- a/main/routes.py
+++ b/main/routes.py
@@ -24,6 +24,7 @@ def register_blueprints(app, api):
         "notifications",
         "health",
         "wallet",
+        "gamification",
     ]
 
     for module in modules:

--- a/migrations/versions/e1f2a3b4c5d6_feat_gamification_mvp.py
+++ b/migrations/versions/e1f2a3b4c5d6_feat_gamification_mvp.py
@@ -1,0 +1,343 @@
+"""Gamification MVP: points ledger, stats, badges, tiers, leaderboard snapshots.
+
+Revision ID: e1f2a3b4c5d6
+Revises: d9e0f1a2b3c4
+"""
+
+from datetime import datetime
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+from app.gamification.constants import TIER_SEED, BADGE_SEED
+
+revision = "e1f2a3b4c5d6"
+down_revision = "d9e0f1a2b3c4"
+branch_labels = None
+depends_on = None
+
+
+def _table_exists(name: str) -> bool:
+    return name in inspect(op.get_bind()).get_table_names()
+
+
+def upgrade():
+    if not _table_exists("gam_points_ledger"):
+        op.create_table(
+            "gam_points_ledger",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "user_id",
+                sa.String(length=12),
+                sa.ForeignKey("users.id"),
+                nullable=False,
+            ),
+            sa.Column("delta", sa.Integer(), nullable=False),
+            sa.Column("reason", sa.String(length=64), nullable=False),
+            sa.Column("ref_type", sa.String(length=32), nullable=True),
+            sa.Column("ref_id", sa.String(length=64), nullable=True),
+            sa.Column(
+                "balance_after", sa.Integer(), nullable=False, server_default="0"
+            ),
+            sa.Column(
+                "created_at",
+                sa.DateTime(),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+        )
+        op.create_index(
+            "ix_gam_points_ledger_user_id", "gam_points_ledger", ["user_id"]
+        )
+        op.create_index(
+            "ix_gam_ledger_user_created", "gam_points_ledger", ["user_id", "created_at"]
+        )
+        op.create_index(
+            "ix_gam_ledger_ref", "gam_points_ledger", ["ref_type", "ref_id"]
+        )
+        op.create_index(
+            "uq_gam_ledger_idempotency",
+            "gam_points_ledger",
+            ["user_id", "reason", "ref_type", "ref_id"],
+            unique=True,
+            postgresql_where=sa.text("ref_id IS NOT NULL"),
+        )
+
+    if not _table_exists("gam_user_stats"):
+        op.create_table(
+            "gam_user_stats",
+            sa.Column(
+                "user_id",
+                sa.String(length=12),
+                sa.ForeignKey("users.id"),
+                primary_key=True,
+            ),
+            sa.Column(
+                "lifetime_points", sa.Integer(), nullable=False, server_default="0"
+            ),
+            sa.Column(
+                "available_points", sa.Integer(), nullable=False, server_default="0"
+            ),
+            sa.Column(
+                "weekly_points", sa.Integer(), nullable=False, server_default="0"
+            ),
+            sa.Column("weekly_period", sa.String(length=8), nullable=True),
+            sa.Column(
+                "current_tier",
+                sa.String(length=20),
+                nullable=False,
+                server_default="newcomer",
+            ),
+            sa.Column(
+                "created_at",
+                sa.DateTime(),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+        )
+
+    if not _table_exists("gam_seller_stats"):
+        op.create_table(
+            "gam_seller_stats",
+            sa.Column(
+                "user_id",
+                sa.String(length=12),
+                sa.ForeignKey("users.id"),
+                primary_key=True,
+            ),
+            sa.Column("total_sales", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("review_count", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("rating_sum", sa.Float(), nullable=False, server_default="0"),
+            sa.Column("avg_rating", sa.Float(), nullable=False, server_default="0"),
+            sa.Column("ship_count", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("ship_hours_sum", sa.Float(), nullable=False, server_default="0"),
+            sa.Column(
+                "on_time_count", sa.Integer(), nullable=False, server_default="0"
+            ),
+            sa.Column("avg_ship_hours", sa.Float(), nullable=True),
+            sa.Column("on_time_pct", sa.Float(), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+        )
+
+    if not _table_exists("gam_badges"):
+        op.create_table(
+            "gam_badges",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("slug", sa.String(length=64), nullable=False, unique=True),
+            sa.Column("name", sa.String(length=120), nullable=False),
+            sa.Column("description", sa.Text(), nullable=True),
+            sa.Column("icon_url", sa.String(length=255), nullable=True),
+            sa.Column("category", sa.String(length=32), nullable=True),
+            sa.Column(
+                "audience", sa.String(length=2), nullable=False, server_default="BS"
+            ),
+            sa.Column("priority", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("criteria_json", sa.JSON(), nullable=False),
+            sa.Column(
+                "is_active", sa.Boolean(), nullable=False, server_default=sa.true()
+            ),
+            sa.Column(
+                "created_at",
+                sa.DateTime(),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+        )
+
+    if not _table_exists("gam_user_badges"):
+        op.create_table(
+            "gam_user_badges",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "user_id",
+                sa.String(length=12),
+                sa.ForeignKey("users.id"),
+                nullable=False,
+            ),
+            sa.Column(
+                "badge_id", sa.Integer(), sa.ForeignKey("gam_badges.id"), nullable=False
+            ),
+            sa.Column("awarded_at", sa.DateTime(), server_default=sa.func.now()),
+            sa.Column("progress_json", sa.JSON(), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.UniqueConstraint("user_id", "badge_id", name="uq_gam_user_badge"),
+        )
+        op.create_index("ix_gam_user_badges_user_id", "gam_user_badges", ["user_id"])
+
+    if not _table_exists("gam_tier_config"):
+        op.create_table(
+            "gam_tier_config",
+            sa.Column("tier", sa.String(length=20), primary_key=True),
+            sa.Column("name", sa.String(length=50), nullable=False),
+            sa.Column("min_lifetime_points", sa.Integer(), nullable=False),
+            sa.Column("color_hex", sa.String(length=7), nullable=False),
+            sa.Column("star_count", sa.Integer(), nullable=False),
+            sa.Column(
+                "created_at",
+                sa.DateTime(),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+        )
+
+    if not _table_exists("gam_leaderboard_snapshot"):
+        op.create_table(
+            "gam_leaderboard_snapshot",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("scope", sa.String(length=20), nullable=False),
+            sa.Column("period_key", sa.String(length=20), nullable=False),
+            sa.Column(
+                "user_id",
+                sa.String(length=12),
+                sa.ForeignKey("users.id"),
+                nullable=False,
+            ),
+            sa.Column("rank", sa.Integer(), nullable=False),
+            sa.Column("points", sa.Integer(), nullable=False),
+            sa.Column("captured_at", sa.DateTime(), server_default=sa.func.now()),
+            sa.Column(
+                "created_at",
+                sa.DateTime(),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+        )
+        op.create_index(
+            "ix_gam_lb_snapshot_scope_period_rank",
+            "gam_leaderboard_snapshot",
+            ["scope", "period_key", "rank"],
+        )
+
+    _seed()
+
+
+def _seed():
+    now = datetime.utcnow()
+
+    tier_table = sa.table(
+        "gam_tier_config",
+        sa.column("tier", sa.String),
+        sa.column("name", sa.String),
+        sa.column("min_lifetime_points", sa.Integer),
+        sa.column("color_hex", sa.String),
+        sa.column("star_count", sa.Integer),
+        sa.column("created_at", sa.DateTime),
+        sa.column("updated_at", sa.DateTime),
+    )
+    bind = op.get_bind()
+    existing_tiers = {
+        r[0] for r in bind.execute(sa.text("SELECT tier FROM gam_tier_config"))
+    }
+    tier_rows = [
+        {**t, "created_at": now, "updated_at": now}
+        for t in TIER_SEED
+        if t["tier"] not in existing_tiers
+    ]
+    if tier_rows:
+        op.bulk_insert(tier_table, tier_rows)
+
+    badge_table = sa.table(
+        "gam_badges",
+        sa.column("slug", sa.String),
+        sa.column("name", sa.String),
+        sa.column("description", sa.Text),
+        sa.column("icon_url", sa.String),
+        sa.column("category", sa.String),
+        sa.column("audience", sa.String),
+        sa.column("priority", sa.Integer),
+        sa.column("criteria_json", sa.JSON),
+        sa.column("is_active", sa.Boolean),
+        sa.column("created_at", sa.DateTime),
+        sa.column("updated_at", sa.DateTime),
+    )
+    existing_badges = {
+        r[0] for r in bind.execute(sa.text("SELECT slug FROM gam_badges"))
+    }
+    badge_rows = []
+    for b in BADGE_SEED:
+        if b["slug"] in existing_badges:
+            continue
+        badge_rows.append(
+            {
+                "slug": b["slug"],
+                "name": b["name"],
+                "description": b.get("description"),
+                "icon_url": b.get("icon_url"),
+                "category": b.get("category"),
+                "audience": b.get("audience", "BS"),
+                "priority": b.get("priority", 0),
+                "criteria_json": b["criteria_json"],
+                "is_active": b.get("is_active", True),
+                "created_at": now,
+                "updated_at": now,
+            }
+        )
+    if badge_rows:
+        op.bulk_insert(badge_table, badge_rows)
+
+
+def downgrade():
+    for tbl in (
+        "gam_leaderboard_snapshot",
+        "gam_user_badges",
+        "gam_badges",
+        "gam_seller_stats",
+        "gam_user_stats",
+        "gam_points_ledger",
+        "gam_tier_config",
+    ):
+        if _table_exists(tbl):
+            op.drop_table(tbl)

--- a/tests/test_gamification_badge_engine.py
+++ b/tests/test_gamification_badge_engine.py
@@ -1,0 +1,155 @@
+"""Unit tests for the pure badge criteria DSL evaluator. No DB/Redis needed."""
+
+import pytest
+
+from app.gamification.badge_engine import evaluate, triggers, progress
+
+
+# --- evaluate: all / any --------------------------------------------------- #
+def test_all_conditions_met():
+    criteria = {
+        "all": [
+            {"stat": "total_sales", "op": ">=", "value": 10},
+            {"stat": "avg_ship_hours", "op": "<", "value": 24},
+        ]
+    }
+    assert evaluate(criteria, {"total_sales": 10, "avg_ship_hours": 23}) is True
+
+
+def test_all_conditions_one_fails():
+    criteria = {
+        "all": [
+            {"stat": "total_sales", "op": ">=", "value": 10},
+            {"stat": "avg_ship_hours", "op": "<", "value": 24},
+        ]
+    }
+    # ship hours exactly 24 fails strict "<"
+    assert evaluate(criteria, {"total_sales": 10, "avg_ship_hours": 24}) is False
+    # sales below threshold fails
+    assert evaluate(criteria, {"total_sales": 9, "avg_ship_hours": 1}) is False
+
+
+def test_any_conditions():
+    criteria = {
+        "any": [
+            {"stat": "a", "op": ">=", "value": 5},
+            {"stat": "b", "op": ">=", "value": 5},
+        ]
+    }
+    assert evaluate(criteria, {"a": 5, "b": 0}) is True
+    assert evaluate(criteria, {"a": 0, "b": 9}) is True
+    assert evaluate(criteria, {"a": 0, "b": 0}) is False
+
+
+def test_all_and_any_combined():
+    criteria = {
+        "all": [{"stat": "x", "op": ">=", "value": 1}],
+        "any": [
+            {"stat": "y", "op": "==", "value": 2},
+            {"stat": "z", "op": "==", "value": 3},
+        ],
+    }
+    assert evaluate(criteria, {"x": 1, "y": 2, "z": 0}) is True
+    assert evaluate(criteria, {"x": 0, "y": 2}) is False  # all fails
+    assert evaluate(criteria, {"x": 1, "y": 0, "z": 0}) is False  # any fails
+
+
+# --- evaluate: edge cases -------------------------------------------------- #
+def test_missing_stat_treated_as_zero():
+    criteria = {"all": [{"stat": "total_sales", "op": ">=", "value": 1}]}
+    assert evaluate(criteria, {}) is False
+
+
+def test_empty_criteria_is_false():
+    assert evaluate({}, {"anything": 100}) is False
+    assert evaluate(None, {"anything": 100}) is False
+
+
+def test_criteria_with_only_trigger_is_not_awardable():
+    # No condition groups -> cannot be awarded on stats alone.
+    assert evaluate({"trigger": ["order.completed"]}, {"x": 1}) is False
+
+
+def test_unknown_operator_is_false():
+    assert evaluate({"all": [{"stat": "x", "op": "~=", "value": 1}]}, {"x": 1}) is False
+
+
+@pytest.mark.parametrize(
+    "op,stat,value,expected",
+    [
+        (">=", 5, 5, True),
+        (">=", 4, 5, False),
+        (">", 6, 5, True),
+        (">", 5, 5, False),
+        ("<=", 5, 5, True),
+        ("<=", 6, 5, False),
+        ("<", 4, 5, True),
+        ("<", 5, 5, False),
+        ("==", 5, 5, True),
+        ("==", 5, 6, False),
+        ("!=", 5, 6, True),
+        ("!=", 5, 5, False),
+    ],
+)
+def test_all_operators(op, stat, value, expected):
+    criteria = {"all": [{"stat": "s", "op": op, "value": value}]}
+    assert evaluate(criteria, {"s": stat}) is expected
+
+
+def test_non_numeric_stat_defaults_to_zero():
+    criteria = {"all": [{"stat": "s", "op": ">=", "value": 1}]}
+    assert evaluate(criteria, {"s": "not-a-number"}) is False
+    assert evaluate(criteria, {"s": None}) is False
+
+
+# --- triggers -------------------------------------------------------------- #
+def test_triggers_returns_list():
+    assert triggers({"trigger": ["order.completed", "review.created"]}) == [
+        "order.completed",
+        "review.created",
+    ]
+
+
+def test_triggers_empty_when_absent():
+    assert triggers({"all": []}) == []
+    assert triggers(None) == []
+
+
+# --- progress -------------------------------------------------------------- #
+def test_progress_threshold_ratio():
+    criteria = {"all": [{"stat": "total_sales", "op": ">=", "value": 50}]}
+    assert progress(criteria, {"total_sales": 25}) == pytest.approx(0.5)
+    assert progress(criteria, {"total_sales": 0}) == 0.0
+
+
+def test_progress_caps_at_one():
+    criteria = {"all": [{"stat": "total_sales", "op": ">=", "value": 10}]}
+    assert progress(criteria, {"total_sales": 999}) == 1.0
+
+
+def test_progress_uses_binding_constraint():
+    # Two conditions -> the minimum ratio drives the bar.
+    criteria = {
+        "all": [
+            {"stat": "a", "op": ">=", "value": 10},
+            {"stat": "b", "op": ">=", "value": 100},
+        ]
+    }
+    # a is 100% (10/10), b is 20% (20/100) -> min = 0.2
+    assert progress(criteria, {"a": 10, "b": 20}) == pytest.approx(0.2)
+
+
+def test_progress_less_than_op_met_or_unmet():
+    criteria = {"all": [{"stat": "avg_ship_hours", "op": "<", "value": 24}]}
+    assert progress(criteria, {"avg_ship_hours": 12}) == 1.0
+    assert progress(criteria, {"avg_ship_hours": 30}) == 0.0
+
+
+def test_progress_zero_target_is_complete():
+    criteria = {"all": [{"stat": "x", "op": ">=", "value": 0}]}
+    assert progress(criteria, {"x": 0}) == 1.0
+
+
+def test_progress_empty_criteria_is_zero():
+    assert progress({}, {"x": 5}) == 0.0
+    assert progress(None, {"x": 5}) == 0.0

--- a/tests/test_gamification_tier_engine.py
+++ b/tests/test_gamification_tier_engine.py
@@ -1,0 +1,135 @@
+"""Unit tests for the pure tier engine (points -> tier). No DB/Redis needed."""
+
+import pytest
+
+from app.gamification.tier_engine import (
+    compute_tier,
+    next_tier,
+    tier_progress,
+    tier_key_for,
+)
+from app.gamification.constants import TIER_SEED
+
+
+# --- compute_tier / tier_key_for ------------------------------------------- #
+@pytest.mark.parametrize(
+    "points,expected",
+    [
+        (0, "newcomer"),
+        (1, "newcomer"),
+        (99, "newcomer"),
+        (100, "hustler"),
+        (499, "hustler"),
+        (500, "trader"),
+        (1499, "trader"),
+        (1500, "merchant"),
+        (4999, "merchant"),
+        (5000, "magnate"),
+        (14999, "magnate"),
+        (15000, "mogul"),
+        (10**9, "mogul"),
+    ],
+)
+def test_tier_boundaries(points, expected):
+    assert tier_key_for(points) == expected
+    assert compute_tier(points)["tier"] == expected
+
+
+def test_negative_points_clamp_to_lowest_tier():
+    assert tier_key_for(-50) == "newcomer"
+
+
+def test_compute_tier_returns_full_row():
+    row = compute_tier(1500)
+    assert row["name"] == "Merchant"
+    assert row["star_count"] == 3
+    assert row["min_lifetime_points"] == 1500
+    assert row["color_hex"].startswith("#")
+
+
+# --- next_tier ------------------------------------------------------------- #
+def test_next_tier_from_newcomer():
+    assert next_tier(0)["tier"] == "hustler"
+
+
+def test_next_tier_mid_ladder():
+    assert next_tier(500)["tier"] == "merchant"
+
+
+def test_next_tier_at_top_is_none():
+    assert next_tier(15000) is None
+    assert next_tier(999999) is None
+
+
+# --- tier_progress --------------------------------------------------------- #
+def test_progress_at_tier_floor_is_zero():
+    prog = tier_progress(100)  # exactly hustler floor
+    assert prog["current"]["tier"] == "hustler"
+    assert prog["progress_to_next"] == 0.0
+    assert prog["points_to_next_tier"] == 400  # 500 - 100
+
+
+def test_progress_midway():
+    # Hustler floor 100, trader floor 500 -> span 400. At 300 -> 200/400 = 0.5.
+    prog = tier_progress(300)
+    assert prog["current"]["tier"] == "hustler"
+    assert prog["next"]["tier"] == "trader"
+    assert prog["progress_to_next"] == pytest.approx(0.5)
+    assert prog["points_to_next_tier"] == 200
+
+
+def test_progress_at_max_tier():
+    prog = tier_progress(20000)
+    assert prog["current"]["tier"] == "mogul"
+    assert prog["next"] is None
+    assert prog["progress_to_next"] == 1.0
+    assert prog["points_to_next_tier"] == 0
+
+
+def test_progress_is_bounded_0_1():
+    for pts in (0, 50, 100, 1234, 4999, 5000, 100000):
+        prog = tier_progress(pts)
+        assert 0.0 <= prog["progress_to_next"] <= 1.0
+
+
+# --- custom tier rows ------------------------------------------------------ #
+def test_custom_unsorted_rows_are_sorted():
+    rows = [
+        {
+            "tier": "b",
+            "name": "B",
+            "star_count": 1,
+            "min_lifetime_points": 100,
+            "color_hex": "#111111",
+        },
+        {
+            "tier": "a",
+            "name": "A",
+            "star_count": 0,
+            "min_lifetime_points": 0,
+            "color_hex": "#000000",
+        },
+        {
+            "tier": "c",
+            "name": "C",
+            "star_count": 2,
+            "min_lifetime_points": 300,
+            "color_hex": "#222222",
+        },
+    ]
+    assert tier_key_for(0, rows) == "a"
+    assert tier_key_for(150, rows) == "b"
+    assert tier_key_for(500, rows) == "c"
+    assert next_tier(150, rows)["tier"] == "c"
+
+
+def test_default_seed_has_six_tiers():
+    assert len(TIER_SEED) == 6
+    assert {t["tier"] for t in TIER_SEED} == {
+        "newcomer",
+        "hustler",
+        "trader",
+        "merchant",
+        "magnate",
+        "mogul",
+    }


### PR DESCRIPTION
## Description

Implements the **Gamification MVP (Phase 1)** from the technical spec, a Points economy, Stars/Tiers progression, Seller Badges, and a Leaderboard. As a single, self-contained `app/gamification/` blueprint.

The feature is wired to existing domain activity via **one-directional signals** (blinker): existing modules emit events after their own commit, and gamification listens. Existing code imports nothing from gamification, so the whole feature can be rolled back by deregistering one blueprint. All new tables are prefixed `gam_` and their foreign keys point *into* `users` only.

- **Points** event-driven awards on orders, posts, reactions, reviews, profile completion, and daily login; append-only ledger with an idempotency guard; reversals on refund/cancel/return.
- **Stars / Tiers**  six tiers driven by lifetime points, computed lazily on read; `tier_changed` realtime event for the level-up animation.
- **Seller Badges** 10-badge catalog stored in the DB with criteria expressed as a small JSON DSL; re-evaluated on the relevant trigger events.
- **Leaderboard**  Redis sorted sets, `global` / `buyers` / `sellers` scopes × `all-time` / `weekly` periods, with the current user's rank pinned and a privacy opt-out.
- **Realtime** `points_awarded`, `badge_earned`, `tier_changed` emitted to the user's room over the existing `/notification` Socket.IO namespace.
- **Anti-abuse**  daily caps on post-creation and reaction points; self-reaction exclusion; idempotency keyed on the source event.

> Scope note: this PR is **backend only** (`markt_python`). The React Native client lives in `markt_mobile` and is a separate PR.

### New module (`app/gamification/`)
| File | Purpose |
|------|---------|
| `models.py` | 7 tables: `gam_points_ledger`, `gam_user_stats`, `gam_seller_stats`, `gam_badges`, `gam_user_badges`, `gam_tier_config`, `gam_leaderboard_snapshot` |
| `constants.py` | Point values, daily caps, tier table, badge catalog, Redis key patterns (all config; no hard-coded values in logic) |
| `tier_engine.py` | Pure points→tier + progress functions |
| `badge_engine.py` | Pure criteria-DSL evaluator (`all`/`any`/`op`) + progress |
| `leaderboard.py` | Redis ZSET ranking: award updates, paged reads, your-rank, opt-out filtering, ISO-week keys |
| `services.py` | `award_points` (atomic ledger + stats + tier recompute, idempotent), reversals, seller-stat maintenance, badge evaluation, read models |
| `events.py` | Signal handlers translating domain events into awards/badges (each wrapped so gamification can never break the host action) |
| `schemas.py` / `routes.py` | 8 REST endpoints under `/api/v1/gamification`, flask-smorest / OpenAPI |

### REST endpoints (session auth via Flask-Login)
- `GET /gamification/me`
- `GET /gamification/users/{id}/profile`
- `GET /gamification/users/{id}/badges`
- `GET /gamification/points/history`
- `GET /gamification/leaderboard`
- `GET /gamification/badges`
- `GET /gamification/tiers`
- `PATCH /gamification/me/preferences`

### Changes to existing files (signal emitters, all post-commit + failure-isolated)
- `app/signals.py` **(new)**  app-wide blinker signals.
- `app/orders/services.py`  emit `order_completed` (both the status and seller item-delivery paths) and `order_reversed` (cancel / return).
- `app/socials/services.py`  emit `post_created`, `post_reaction_added` (via `like_post`), `review_created`.
- `app/users/services.py`  emit `profile_completed` (profile/avatar updates, idempotent).
- `app/users/routes.py`  emit `daily_login` on login.
- `app/notifications/sockets.py`  add a `register` handler so per-user server pushes reach the client's `user_{id}` room.
- `main/routes.py`  register the blueprint.

### Migration
- `e1f2a3b4c5d6_feat_gamification_mvp.py` creates all 7 `gam_` tables, the ledger idempotency **partial unique index** `(user_id, reason, ref_type, ref_id) WHERE ref_id IS NOT NULL`, and seeds `gam_tier_config` (6 tiers) + `gam_badges` (10 badges). Idempotent, with a reversible `downgrade()`.

---

## Tickets
Ticket ID: [link]

## Related Issue
Fixes #[Issue number]

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

**Unit tests — pure engines (spec DoD target: 90%):**

```
$ pytest tests/test_gamification_tier_engine.py tests/test_gamification_badge_engine.py
53 passed

Name                               Stmts   Miss  Cover
-----------------------------------------------------
app/gamification/badge_engine.py      39      0   100%
app/gamification/tier_engine.py       31      0   100%
-----------------------------------------------------
TOTAL                                 70      0   100%
```

- `tier_engine`: every tier boundary (incl. just-below/at-threshold pairs), negative-points clamp, `next_tier` at the top, progress bounds (0..1, floor 0.0, max-tier 1.0), and custom unsorted tier rows.
- `badge_engine`: `all`/`any`/combined logic, missing/non-numeric/`None` stats, empty/None/trigger-only criteria, all six operators, `triggers` extraction, and `progress` (threshold ratio, cap at 1, binding-constraint min, `<`-op, zero-target).

**Static checks:** `flake8` (repo config) and `black` clean across all new and modified files.

**Not yet covered here (needs a DB/Redis env):** integration tests for the REST endpoints, the idempotency "fire-the-same-event-twice" path, and the Redis leaderboard sequence assertions (spec §8). These require the app fixture + Postgres/Redis and are recommended as a follow-up before launch.

## Tested & Approved by?
[QA Engineer]

## Checklist
- [x] My code follows the project's style guidelines (flake8 + black clean)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (pure-engine unit tests)
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

**Deploy steps**
1. Run the migration: `flask db upgrade` (revision `e1f2a3b4c5d6`). It creates the `gam_` tables and seeds tiers + badges.
2. No Redis pre-seeding needed as the leaderboard sorted sets fill on the first awards; a cold Redis rebuilds from `gam_user_stats`.

**Design decisions worth a look during review**
- **Idempotency** is enforced twice: a service-layer pre-check *and* the ledger's unique partial index. Duplicate events (retries, double webhooks) are swallowed which is the single most important rule of the points system.
- **User-id mapping:** orders reference buyer/seller by integer account id, so the events layer resolves `Order.buyer -> user_id` and `OrderItem.seller -> user_id`. Signals fire post-commit, so handlers re-query (orders/review) or receive lightweight value carriers (post/review) to avoid detached-instance lazy loads.
- **Realtime** reuses the `/notification` namespace; the new `register` socket handler joins the caller to `user_{id}` (this was previously missing, so per-user pushes had no room to land in).
- **Opt-out** is stored in a Redis set for the MVP (no schema change); opted-out users still see their own rank but are filtered from the public list.

**Deferred / out of scope (documented, listeners left ready)**
- `referral_first_paid` no referral system exists in the codebase yet (no referrer/referee link), so it cannot be emitted. One `send()` away once that feature ships.
- `seller.verified` nothing in the code sets `verification_status = VERIFIED` (done out-of-band), so there's no transition to hook. Not a functional gap: the `verified_seller` badge also triggers on `order.completed`, so it still unlocks on the next sale.
- `ship_hours` is not yet computed (needs order shipped/delivered timestamps), so `fast_shipper` won't unlock until that plumbing is added; the columns and criteria are ready.
- V2 items (points redemption, achievements, quests, engagement-driven post points, push notifications) are explicitly out of the MVP per the spec.

**Appendix values shipped** point values (Appendix A), 6-tier table (Appendix C), and 10-badge catalog (Appendix B) are seeded from `constants.py`; the `trendsetter` badge is seeded **inactive** because its attribution is a V2 mechanic.
