### PR TITLE
feat: implement push notification system with Expo tokens

### DIFF
--- a/app/gamification/services.py
+++ b/app/gamification/services.py
@@ -140,6 +140,16 @@ def _emit(user_id: str, event: str, data: dict) -> None:
         logger.debug(f"gamification emit {event} failed for {user_id}: {e}")
 
 
+def _push(user_id: str, title: str, body: str, data: dict = None) -> None:
+    """Best-effort remote push so gamification wins reach a closed app."""
+    try:
+        from app.notifications.services import PushService
+
+        PushService.send_to_user(user_id, title, body, data or {})
+    except Exception as e:  # pragma: no cover - push best-effort
+        logger.debug(f"gamification push failed for {user_id}: {e}")
+
+
 # --------------------------------------------------------------------------- #
 # Core: award / reverse points
 # --------------------------------------------------------------------------- #
@@ -264,6 +274,12 @@ def award_points(
                     "new_tier": result["new_tier"],
                     "stars": result["star_count"],
                 },
+            )
+            _push(
+                user_id,
+                "Level up! 🌟",
+                f"You reached a new tier — {result['star_count']}★.",
+                {"type": "tier_changed", "new_tier": result["new_tier"]},
             )
     return result
 
@@ -521,6 +537,12 @@ def evaluate_badges_for(user_id: str, trigger: str) -> list:
                     "description": badge.description,
                 }
             },
+        )
+        _push(
+            user_id,
+            "Badge unlocked! 🎉",
+            f"You earned the {badge.name} badge.",
+            {"type": "badge_earned", "slug": badge.slug},
         )
     if newly:
         _invalidate_stats_cache(user_id)

--- a/app/notifications/models.py
+++ b/app/notifications/models.py
@@ -68,3 +68,16 @@ class Notification(BaseModel):
             "created_at": self.created_at,
             "metadata_": self.metadata_ or {},
         }
+
+
+class PushToken(BaseModel):
+    """A device's Expo push token, for remote push notifications."""
+
+    __tablename__ = "push_tokens"
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(
+        db.String(12), db.ForeignKey("users.id"), nullable=False, index=True
+    )
+    token = db.Column(db.String(255), nullable=False, unique=True)
+    platform = db.Column(db.String(20), nullable=True)  # ios / android

--- a/app/notifications/routes.py
+++ b/app/notifications/routes.py
@@ -14,8 +14,10 @@ from .schemas import (
     UnreadCountSchema,
     MarkAsReadRequestSchema,
     MarkAsReadResponseSchema,
+    PushTokenSchema,
+    PushTokenDeleteSchema,
 )
-from .services import NotificationService
+from .services import NotificationService, PushService
 
 bp = Blueprint(
     "notifications",
@@ -60,3 +62,22 @@ class MarkAsRead(MethodView):
             current_user.id, data.get("notification_ids")
         )
         return {"updated": updated}
+
+
+@bp.route("/push-token")
+class PushTokenResource(MethodView):
+    @login_required
+    @bp.arguments(PushTokenSchema)
+    @bp.response(204)
+    def post(self, data):
+        """Register this device's Expo push token for the current user."""
+        PushService.register_token(current_user.id, data["token"], data.get("platform"))
+        return None
+
+    @login_required
+    @bp.arguments(PushTokenDeleteSchema)
+    @bp.response(204)
+    def delete(self, data):
+        """Remove a push token (e.g. on logout)."""
+        PushService.remove_token(data["token"])
+        return None

--- a/app/notifications/schemas.py
+++ b/app/notifications/schemas.py
@@ -29,3 +29,14 @@ class MarkAsReadRequestSchema(Schema):
 
 class MarkAsReadResponseSchema(Schema):
     updated = fields.Int()
+
+
+class PushTokenSchema(Schema):
+    token = fields.Str(required=True)
+    platform = fields.Str(
+        required=False, validate=validate.OneOf(["ios", "android", "web"])
+    )
+
+
+class PushTokenDeleteSchema(Schema):
+    token = fields.Str(required=True)

--- a/app/notifications/services.py
+++ b/app/notifications/services.py
@@ -327,32 +327,42 @@ class NotificationService:
             # Format message with safe defaults
             format_data = {
                 "username": actor_name or "Someone",
-                "product_name": metadata_.get("product_name", "your product")
-                if metadata_
-                else "your product",
+                "product_name": (
+                    metadata_.get("product_name", "your product")
+                    if metadata_
+                    else "your product"
+                ),
                 "rating": metadata_.get("rating", 0) if metadata_ else 0,
                 "order_id": reference_id or "N/A",
-                "status": metadata_.get("status", "updated")
-                if metadata_
-                else "updated",
+                "status": (
+                    metadata_.get("status", "updated") if metadata_ else "updated"
+                ),
                 "message": metadata_.get("message", "") if metadata_ else "",
                 # Buyer request variables
-                "seller_name": metadata_.get("seller_name", "A seller")
-                if metadata_
-                else "A seller",
-                "request_title": metadata_.get("request_title", "your request")
-                if metadata_
-                else "your request",
+                "seller_name": (
+                    metadata_.get("seller_name", "A seller")
+                    if metadata_
+                    else "A seller"
+                ),
+                "request_title": (
+                    metadata_.get("request_title", "your request")
+                    if metadata_
+                    else "your request"
+                ),
                 # Social variables
-                "inviter_name": metadata_.get("inviter_name", "Someone")
-                if metadata_
-                else "Someone",
-                "niche_name": metadata_.get("niche_name", "a community")
-                if metadata_
-                else "a community",
-                "action_type": metadata_.get("action_type", "moderation")
-                if metadata_
-                else "moderation",
+                "inviter_name": (
+                    metadata_.get("inviter_name", "Someone") if metadata_ else "Someone"
+                ),
+                "niche_name": (
+                    metadata_.get("niche_name", "a community")
+                    if metadata_
+                    else "a community"
+                ),
+                "action_type": (
+                    metadata_.get("action_type", "moderation")
+                    if metadata_
+                    else "moderation"
+                ),
             }
 
             message = template["message"].format(**format_data)
@@ -566,3 +576,103 @@ class NotificationService:
             ).update({"is_seen": True}, synchronize_session=False)
         except Exception as e:
             logger.error(f"Error marking notifications as seen: {str(e)}")
+
+
+class PushService:
+    """Remote push notifications via the Expo Push API.
+
+    Tokens are Expo push tokens (``ExponentPushToken[...]``) registered by the
+    mobile client. Sending is best-effort; invalid tokens returned by Expo
+    (``DeviceNotRegistered``) are pruned so we stop pushing to dead devices.
+    """
+
+    EXPO_PUSH_URL = "https://exp.host/--/api/v2/push/send"
+
+    @staticmethod
+    def register_token(user_id: str, token: str, platform: str = None) -> None:
+        from .models import PushToken
+
+        if not token:
+            return
+        with session_scope() as session:
+            existing = session.query(PushToken).filter_by(token=token).first()
+            if existing:
+                existing.user_id = user_id
+                if platform:
+                    existing.platform = platform
+            else:
+                session.add(PushToken(user_id=user_id, token=token, platform=platform))
+
+    @staticmethod
+    def remove_token(token: str) -> None:
+        from .models import PushToken
+
+        with session_scope() as session:
+            session.query(PushToken).filter_by(token=token).delete()
+
+    @staticmethod
+    def get_user_tokens(user_id: str) -> List[str]:
+        from .models import PushToken
+
+        with session_scope() as session:
+            return [
+                t.token
+                for t in session.query(PushToken).filter_by(user_id=user_id).all()
+            ]
+
+    @staticmethod
+    def send_to_user(
+        user_id: str, title: str, body: str, data: Dict[str, Any] = None
+    ) -> None:
+        tokens = PushService.get_user_tokens(user_id)
+        if tokens:
+            PushService.send_to_tokens(tokens, title, body, data)
+
+    @staticmethod
+    def send_to_tokens(
+        tokens: List[str], title: str, body: str, data: Dict[str, Any] = None
+    ) -> None:
+        import requests
+
+        messages = [
+            {
+                "to": t,
+                "title": title,
+                "body": body,
+                "data": data or {},
+                "sound": "default",
+                "channelId": "default",
+            }
+            for t in tokens
+            if str(t).startswith("ExponentPushToken")
+        ]
+        if not messages:
+            return
+        try:
+            resp = requests.post(
+                PushService.EXPO_PUSH_URL,
+                json=messages,
+                headers={
+                    "Content-Type": "application/json",
+                    "Accept": "application/json",
+                },
+                timeout=10,
+            )
+            PushService._prune_invalid(resp, messages)
+        except Exception as e:
+            logger.error(f"Expo push send failed: {e}")
+
+    @staticmethod
+    def _prune_invalid(resp, messages) -> None:
+        """Remove tokens Expo reports as no longer registered."""
+        try:
+            tickets = (resp.json() or {}).get("data", [])
+        except Exception:
+            return
+        for msg, ticket in zip(messages, tickets):
+            if (
+                isinstance(ticket, dict)
+                and ticket.get("status") == "error"
+                and (ticket.get("details") or {}).get("error") == "DeviceNotRegistered"
+            ):
+                PushService.remove_token(msg["to"])

--- a/app/notifications/tasks.py
+++ b/app/notifications/tasks.py
@@ -67,12 +67,27 @@ def deliver_notification(self, notification_data: Dict, channels: List[str]):
 
 @celery_app.task(bind=True, queue="notifications")
 def send_push_notification(self, notification_data: Dict):
-    """Send push notification to mobile devices"""
+    """Send push notification to the user's registered devices via Expo Push."""
     try:
-        # Placeholder for push notification service integration
-        # Example: FCM, APNs, etc.
+        from .services import PushService
+
+        user_id = notification_data.get("user_id")
+        if not user_id:
+            return
+        title = notification_data.get("title") or "Markt"
+        body = notification_data.get("message") or notification_data.get("body") or ""
+        PushService.send_to_user(
+            user_id,
+            title,
+            body,
+            {
+                "type": notification_data.get("type"),
+                "reference_type": notification_data.get("reference_type"),
+                "reference_id": notification_data.get("reference_id"),
+            },
+        )
         logger.info(
-            f"Push notification sent for notification {notification_data['id']}"
+            f"Push notification dispatched for notification {notification_data.get('id')}"
         )
     except Exception as e:
         logger.error(f"Push notification failed: {str(e)}")

--- a/migrations/versions/f2a3b4c5d6e7_feat_push_tokens.py
+++ b/migrations/versions/f2a3b4c5d6e7_feat_push_tokens.py
@@ -1,0 +1,52 @@
+"""Push notification tokens (Expo push).
+
+Revision ID: f2a3b4c5d6e7
+Revises: e1f2a3b4c5d6
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+revision = "f2a3b4c5d6e7"
+down_revision = "e1f2a3b4c5d6"
+branch_labels = None
+depends_on = None
+
+
+def _table_exists(name: str) -> bool:
+    return name in inspect(op.get_bind()).get_table_names()
+
+
+def upgrade():
+    if not _table_exists("push_tokens"):
+        op.create_table(
+            "push_tokens",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "user_id",
+                sa.String(length=12),
+                sa.ForeignKey("users.id"),
+                nullable=False,
+            ),
+            sa.Column("token", sa.String(length=255), nullable=False, unique=True),
+            sa.Column("platform", sa.String(length=20), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+        )
+        op.create_index("ix_push_tokens_user_id", "push_tokens", ["user_id"])
+
+
+def downgrade():
+    if _table_exists("push_tokens"):
+        op.drop_table("push_tokens")


### PR DESCRIPTION
## Description

Implements the **backend for push notifications** device push-token registration and remote delivery via the **Expo Push API** and turns the previously stubbed `send_push_notification` task into a real sender.

This is the server counterpart to the mobile notifications work (`markt_mobile`: `expo-notifications` + a background reminder worker). The client registers its Expo push token on login and de-registers on logout; this PR stores those tokens, sends notifications to a user's devices, and prunes tokens Expo reports as dead. It also wires the first server-driven pushes into gamification (badge earned / tier up), so those wins reach a user even when the app is closed.

### What's included

**New: push-token storage**
- `app/notifications/models.py` `PushToken` (`user_id`, unique `token`, `platform`). FK into `users` only.
- `migrations/versions/f2a3b4c5d6e7_feat_push_tokens.py` creates `push_tokens` (idempotent; reversible `downgrade()`).

**New: `PushService` (`app/notifications/services.py`)**
- `register_token` / `remove_token` / `get_user_tokens`
- `send_to_user` / `send_to_tokens` batches messages to the Expo Push API (`https://exp.host/--/api/v2/push/send`), filtered to valid `ExponentPushToken[...]` values.
- `_prune_invalid` removes tokens returned as `DeviceNotRegistered` so we stop pushing to uninstalled/dead devices.
- Sending is best-effort and fully exception-guarded — a push failure never affects the caller.

**REST (`app/notifications/routes.py`, `schemas.py`)**
- `POST /api/v1/notifications/push-token`  register the current user's device token.
- `DELETE /api/v1/notifications/push-token` remove a token (logout).
- `PushTokenSchema` / `PushTokenDeleteSchema`.

**Task (`app/notifications/tasks.py`)**
- `send_push_notification` was a placeholder that only logged; it now resolves the user's tokens and dispatches through `PushService`.

**Gamification → push (`app/gamification/services.py`)**
- A small `_push` helper (lazy import, best-effort) plus pushes on **badge earned** ("Badge unlocked! 🎉") and **tier up** ("Level up! 🌟"), alongside the existing Socket.IO realtime events.

---

## Tickets
Ticket ID: [link]

## Related Issue
Fixes #[Issue number]

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

**Static checks:** `py_compile`, `flake8` (repo config), and `black` are clean across all changed files.

**Not covered by automated tests here:** delivery is an outbound HTTP integration with Expo, so it is exercised manually rather than unit-tested (no new unit tests in this PR). End-to-end verification requires:
- FCM configured for the Android app (see Deploy notes) — without it, tokens register but Android push won't deliver.
- A physical device on an EAS build (push does not work in Expo Go).

Suggested manual QA:
1. Log in on a device build → `POST /notifications/push-token` fires; confirm a row in `push_tokens`.
2. Earn a badge / cross a tier threshold → device receives the push (app backgrounded/closed).
3. Log out → `DELETE /notifications/push-token`; confirm the row is gone.
4. Uninstall and re-trigger a send → the token is pruned on the `DeviceNotRegistered` response.

## Tested & Approved by?
[QA Engineer]

## Checklist
- [x] My code follows the project's style guidelines (flake8 + black clean)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (I/O integration — verified manually; see above)
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

**Deploy steps**
1. Run the migration: `flask db upgrade` (revision `f2a3b4c5d6e7`, chained after the gamification head `e1f2a3b4c5d6`).
2. **FCM (required for Android delivery):** add `google-services.json` to the mobile app and configure FCM V1 credentials for the EAS project. Token registration and the send path work without it, but Android notifications won't be delivered until FCM is set up.
3. No new environment variables Expo's push endpoint needs no server-side key for sending.

**Design notes for review**
- Tokens are unique; re-registering an existing token just re-points it at the current user (handles device hand-off / re-login).
- Delivery is best-effort and isolated: every send path swallows exceptions and logs, so notifications can never break the triggering action (order, review, gamification award, etc.).
- The gamification push reuses the same award pipeline that already emits Socket.IO events — push is additive, not a replacement, so in-app realtime still works when the app is open.

**Follow-ups (out of scope)**
- Respect a per-user push preference (e.g. `UserSettings.push_notifications`) before sending.
- Wire more server events to push (order shipped/delivered, chat messages) via the existing `send_push_notification` task.
- Batching/retry for large fan-outs (Expo accepts up to 100 messages per request).
