### PR TITLE
fix(wallet): sellers keep 100% of item price on settlement

### DIFF
--- a/app/wallet/services.py
+++ b/app/wallet/services.py
@@ -21,7 +21,9 @@ from .paystack_subaccounts import PaystackSubaccountClient
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_COMMISSION_RATE = 0.10
+# Sellers keep 100% of item price for now — Markt earns only via the buyer-facing
+# service fee, not a seller-side commission.
+DEFAULT_COMMISSION_RATE = 0.0
 MIN_WITHDRAWAL_AMOUNT = 1000.0
 
 


### PR DESCRIPTION
## Description
Sellers now keep 100% of their item price on settlement. Markt's take is the
buyer-facing service fee only (2.5%, floor ₦25, ceiling ₦1,000). There is no
separate seller-side commission. Drops `DEFAULT_COMMISSION_RATE` from 0.10
to 0.0 in `WalletService.settle_order_item` (app/wallet/services.py).

## Tickets
Ticket ID [link]

## Related Issue
Fixes #[Issue number]

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?
`pytest tests/test_wallet.py tests/test_phase3_marketplace.py` 11 passed.
`test_settle_order_item_calculates_net_after_commission` derives its
expected value from the constant, so it verifies the new 0% rate
automatically.

## Tested & Approved by?
[QA Engineer]

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
Business decision (Phase 0 of the Markt delivery spec rollout): single fee,
sellers keep 100%. Constant is kept configurable rather than deleted, since
seller-side charges are a possible future direction.