### PR TITLE
fix(deliveries): QR proof-of-delivery now triggers seller settlement

### DIFF
--- a/app/deliveries/services.py
+++ b/app/deliveries/services.py
@@ -719,6 +719,8 @@ class DeliveryService:
 
     @staticmethod
     def confirm_order_qr_code(user_id: str, order_id: str, qr_code: str) -> Dict:
+        from app.wallet.services import WalletService
+
         with session_scope() as session:
             # query the assignment to get the escrow QR code
             assignment = (
@@ -742,17 +744,26 @@ class DeliveryService:
                 )
                 raise ValidationError("Invalid QR code")
 
-            # Mark the order as delivered
             order = session.query(Order).filter_by(id=order_id).first()
             if not order:
                 logger.warning(f"No order found with ID {order_id}")
                 raise NotFoundError("Order not found")
 
-            order.status = OrderStatus.DELIVERED
+            # POD is the trigger for escrow release: settle every item's seller now,
+            # not just items a seller separately marked shipped/delivered themselves.
+            for item in order.items:
+                item.status = OrderItem.Status.DELIVERED
+                WalletService.settle_order_item(item)
+
             assignment.logistical_status = LogisticalStatus.COMPLETED
             session.commit()
 
-            return {"status": "success", "message": "Order marked as delivered"}
+        # Delegate order-level completion (status, realtime event, gamification)
+        # to the single source of truth so the QR path gets the same side effects
+        # as every other way an order can be marked delivered.
+        OrderService.update_order_status(order_id, OrderStatus.DELIVERED)
+
+        return {"status": "success", "message": "Order marked as delivered"}
 
     @staticmethod
     def find_delivery_order_buyer(user_id: str, room_id: str) -> bool:

--- a/tests/test_deliveries.py
+++ b/tests/test_deliveries.py
@@ -1,0 +1,73 @@
+"""Unit tests for the delivery QR proof-of-delivery flow."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.deliveries.models import AssignmentStatus, LogisticalStatus
+from app.deliveries.services import DeliveryService
+from app.libs.errors import ValidationError
+from app.orders.models import OrderItem, OrderStatus
+
+
+def _session_with(assignment, order):
+    session = MagicMock()
+
+    def query_side_effect(model):
+        mock = MagicMock()
+        if model.__name__ == "DeliveryOrderAssignment":
+            mock.filter_by.return_value.first.return_value = assignment
+        elif model.__name__ == "Order":
+            mock.filter_by.return_value.first.return_value = order
+        else:
+            mock.filter_by.return_value.first.return_value = None
+        return mock
+
+    session.query.side_effect = query_side_effect
+    return session
+
+
+@patch("app.orders.services.OrderService.update_order_status")
+@patch("app.wallet.services.WalletService.settle_order_item")
+def test_confirm_order_qr_code_settles_every_item_and_completes_order(
+    mock_settle, mock_update_status
+):
+    item_a = SimpleNamespace(id=1, status=OrderItem.Status.PROCESSING, seller_id=7)
+    item_b = SimpleNamespace(id=2, status=OrderItem.Status.PROCESSING, seller_id=8)
+    order = SimpleNamespace(id="ORD_1", items=[item_a, item_b])
+    assignment = SimpleNamespace(
+        escrow_qr_code="QR123",
+        status=AssignmentStatus.ACCEPTED,
+        logistical_status=LogisticalStatus.DELIVERED_PENDING_QR,
+    )
+
+    session = _session_with(assignment, order)
+
+    with patch("app.deliveries.services.session_scope") as mock_scope:
+        mock_scope.return_value.__enter__.return_value = session
+        result = DeliveryService.confirm_order_qr_code("DEL_1", "ORD_1", "QR123")
+
+    assert result == {"status": "success", "message": "Order marked as delivered"}
+    assert item_a.status == OrderItem.Status.DELIVERED
+    assert item_b.status == OrderItem.Status.DELIVERED
+    assert mock_settle.call_count == 2
+    assert assignment.logistical_status == LogisticalStatus.COMPLETED
+    mock_update_status.assert_called_once_with("ORD_1", OrderStatus.DELIVERED)
+
+
+@patch("app.orders.services.OrderService.update_order_status")
+@patch("app.wallet.services.WalletService.settle_order_item")
+def test_confirm_order_qr_code_rejects_wrong_code(mock_settle, mock_update_status):
+    assignment = SimpleNamespace(
+        escrow_qr_code="QR123", status=AssignmentStatus.ACCEPTED
+    )
+    session = _session_with(assignment, order=None)
+
+    with patch("app.deliveries.services.session_scope") as mock_scope:
+        mock_scope.return_value.__enter__.return_value = session
+        with pytest.raises(ValidationError):
+            DeliveryService.confirm_order_qr_code("DEL_1", "ORD_1", "WRONG")
+
+    mock_settle.assert_not_called()
+    mock_update_status.assert_not_called()


### PR DESCRIPTION
## Description
The rider's QR proof-of-delivery scan (`confirm_order_qr_code`) previously
set `Order.status = DELIVERED` directly, bypassing `OrderItem` status and
`WalletService.settle_order_item` entirely. The actual POD handshake never
released escrow to sellers. Only a separate, seller-initiated status-update
path did that.

Now the QR confirmation marks every item on the order `DELIVERED` and
settles each one, then delegates order-level completion to
`OrderService.update_order_status` so the realtime order-status event and
the gamification hook fire the same way they do for every other completion
path.

## Tickets
Ticket ID [link]

## Related Issue
Fixes #[Issue number]

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?
`pytest tests/`  92 passed (0 failed), including two new tests added in
`tests/test_deliveries.py`:
- `test_confirm_order_qr_code_settles_every_item_and_completes_order`
- `test_confirm_order_qr_code_rejects_wrong_code`

## Tested & Approved by?
[QA Engineer]

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
Found during a Phase 0 audit of the delivery spec rollout. this is a real
money-path gap in production code, not a new feature. Pairs with
`fix/wallet-drop-seller-commission` and `fix/stop-paystack-split-payments`.